### PR TITLE
feat: integrate task lock workflow and align review frontend with backend APIs

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -23,6 +23,12 @@
     </properties>
 
     <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>

--- a/backend/src/main/java/com/heritage/platform/HeritagePlatformApplication.java
+++ b/backend/src/main/java/com/heritage/platform/HeritagePlatformApplication.java
@@ -2,8 +2,10 @@ package com.heritage.platform;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class HeritagePlatformApplication {
 
     public static void main(String[] args) {

--- a/backend/src/main/java/com/heritage/platform/config/JwtAuthFilter.java
+++ b/backend/src/main/java/com/heritage/platform/config/JwtAuthFilter.java
@@ -40,11 +40,13 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
             if (jwtService.validateToken(token)) {
                 String email = jwtService.getEmailFromToken(token);
+                String userId = jwtService.getUserIdFromToken(token);
                 String role = jwtService.getRoleFromToken(token);
 
                 SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + role);
+                // Use userId as principal for easier UUID conversion
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(email, null, List.of(authority));
+                        new UsernamePasswordAuthenticationToken(userId, null, List.of(authority));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/backend/src/main/java/com/heritage/platform/config/JwtAuthFilter.java
+++ b/backend/src/main/java/com/heritage/platform/config/JwtAuthFilter.java
@@ -40,13 +40,11 @@ public class JwtAuthFilter extends OncePerRequestFilter {
 
             if (jwtService.validateToken(token)) {
                 String email = jwtService.getEmailFromToken(token);
-                String userId = jwtService.getUserIdFromToken(token);
                 String role = jwtService.getRoleFromToken(token);
 
                 SimpleGrantedAuthority authority = new SimpleGrantedAuthority("ROLE_" + role);
-                // Use userId as principal for easier UUID conversion
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(userId, null, List.of(authority));
+                        new UsernamePasswordAuthenticationToken(email, null, List.of(authority));
 
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }

--- a/backend/src/main/java/com/heritage/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/heritage/platform/config/SecurityConfig.java
@@ -70,6 +70,7 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE, "/api/tags/**").hasRole("ADMINISTRATOR")
                 // Review workflow
                 .requestMatchers("/api/reviews/**").hasAnyRole("REVIEWER", "ADMINISTRATOR")
+                .requestMatchers("/api/tasks/**").hasAnyRole("REVIEWER", "ADMINISTRATOR")
                 // Resource authoring and contributor workflow
                 .requestMatchers(HttpMethod.POST, "/api/resources").hasAnyRole("CONTRIBUTOR", "REVIEWER", "ADMINISTRATOR")
                 .requestMatchers(HttpMethod.PUT, "/api/resources/**").hasAnyRole("CONTRIBUTOR", "REVIEWER", "ADMINISTRATOR")

--- a/backend/src/main/java/com/heritage/platform/config/SecurityConfig.java
+++ b/backend/src/main/java/com/heritage/platform/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
                 // Public authentication endpoints
                 .requestMatchers("/api/auth/register", "/api/auth/login").permitAll()
+                .requestMatchers("/api/tasks/health").permitAll()
+                .requestMatchers("/api/tasks/**").hasAnyRole("REVIEWER", "ADMINISTRATOR")
                 // Public discovery endpoints
                 .requestMatchers("/api/search/**").permitAll()
                 .requestMatchers(HttpMethod.GET, "/api/categories").permitAll()
@@ -70,7 +72,6 @@ public class SecurityConfig {
                 .requestMatchers(HttpMethod.DELETE, "/api/tags/**").hasRole("ADMINISTRATOR")
                 // Review workflow
                 .requestMatchers("/api/reviews/**").hasAnyRole("REVIEWER", "ADMINISTRATOR")
-                .requestMatchers("/api/tasks/**").hasAnyRole("REVIEWER", "ADMINISTRATOR")
                 // Resource authoring and contributor workflow
                 .requestMatchers(HttpMethod.POST, "/api/resources").hasAnyRole("CONTRIBUTOR", "REVIEWER", "ADMINISTRATOR")
                 .requestMatchers(HttpMethod.PUT, "/api/resources/**").hasAnyRole("CONTRIBUTOR", "REVIEWER", "ADMINISTRATOR")

--- a/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
+++ b/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
@@ -2,11 +2,7 @@ package com.heritage.platform.controller;
 
 import com.heritage.platform.dto.ResourceResponse;
 import com.heritage.platform.model.Resource;
-import com.heritage.platform.model.User;
 import com.heritage.platform.service.TaskAllocationService;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import org.springframework.web.bind.annotation.*;
@@ -16,11 +12,13 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/tasks")
-@Profile("!test")
 public class TaskAllocationController {
 
-    @Autowired
-    private TaskAllocationService taskAllocationService;
+    private final TaskAllocationService taskAllocationService;
+
+    public TaskAllocationController(TaskAllocationService taskAllocationService) {
+        this.taskAllocationService = taskAllocationService;
+    }
 
     /**
      * Health check endpoint (no auth required)
@@ -35,8 +33,7 @@ public class TaskAllocationController {
      */
     @PostMapping("/next")
     public ResponseEntity<ResourceResponse> getNextTask(Principal principal) {
-        UUID reviewerId = UUID.fromString(principal.getName());
-        Resource resource = taskAllocationService.getNextTask(reviewerId);
+        Resource resource = taskAllocationService.getNextTask(principal.getName());
         
         if (resource == null) {
             return ResponseEntity.noContent().build();
@@ -52,7 +49,7 @@ public class TaskAllocationController {
     public ResponseEntity<Void> releaseTask(
             @PathVariable UUID resourceId,
             Principal principal) {
-        taskAllocationService.releaseTask(resourceId);
+        taskAllocationService.releaseTask(resourceId, principal.getName());
         return ResponseEntity.ok().build();
     }
 }

--- a/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
+++ b/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
@@ -1,0 +1,48 @@
+package com.heritage.platform.controller;
+
+import com.heritage.platform.dto.ResourceResponse;
+import com.heritage.platform.model.Resource;
+import com.heritage.platform.model.User;
+import com.heritage.platform.service.TaskAllocationService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import org.springframework.web.bind.annotation.*;
+
+import java.security.Principal;
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/tasks")
+public class TaskAllocationController {
+
+    @Autowired
+    private TaskAllocationService taskAllocationService;
+
+    /**
+     * Get next task from pool and lock it for current reviewer
+     */
+    @PostMapping("/next")
+    public ResponseEntity<ResourceResponse> getNextTask(Principal principal) {
+        UUID reviewerId = UUID.fromString(principal.getName());
+        Resource resource = taskAllocationService.getNextTask(reviewerId);
+        
+        if (resource == null) {
+            return ResponseEntity.noContent().build();
+        }
+        
+        return ResponseEntity.ok(ResourceResponse.fromEntity(resource));
+    }
+
+    /**
+     * Release a task back to the pool
+     */
+    @PostMapping("/{resourceId}/release")
+    public ResponseEntity<Void> releaseTask(
+            @PathVariable UUID resourceId,
+            Principal principal) {
+        taskAllocationService.releaseTask(resourceId);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
+++ b/backend/src/main/java/com/heritage/platform/controller/TaskAllocationController.java
@@ -5,6 +5,7 @@ import com.heritage.platform.model.Resource;
 import com.heritage.platform.model.User;
 import com.heritage.platform.service.TaskAllocationService;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -15,10 +16,19 @@ import java.util.UUID;
 
 @RestController
 @RequestMapping("/api/tasks")
+@Profile("!test")
 public class TaskAllocationController {
 
     @Autowired
     private TaskAllocationService taskAllocationService;
+
+    /**
+     * Health check endpoint (no auth required)
+     */
+    @GetMapping("/health")
+    public ResponseEntity<String> health() {
+        return ResponseEntity.ok("Task allocation service is running");
+    }
 
     /**
      * Get next task from pool and lock it for current reviewer

--- a/backend/src/main/java/com/heritage/platform/exception/FileSizeLimitExceededException.java
+++ b/backend/src/main/java/com/heritage/platform/exception/FileSizeLimitExceededException.java
@@ -1,0 +1,7 @@
+package com.heritage.platform.exception;
+
+public class FileSizeLimitExceededException extends RuntimeException {
+    public FileSizeLimitExceededException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/heritage/platform/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/heritage/platform/exception/GlobalExceptionHandler.java
@@ -78,6 +78,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(400, ex.getMessage()));
     }
 
+    @ExceptionHandler(TaskLockedByAnotherUserException.class)
+    public ResponseEntity<ErrorResponse> handleTaskLockedByAnotherUser(TaskLockedByAnotherUserException ex) {
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(new ErrorResponse(403, ex.getMessage()));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/backend/src/main/java/com/heritage/platform/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/com/heritage/platform/exception/GlobalExceptionHandler.java
@@ -72,6 +72,12 @@ public class GlobalExceptionHandler {
                 .body(new ErrorResponse(400, ex.getMessage()));
     }
 
+    @ExceptionHandler(FileSizeLimitExceededException.class)
+    public ResponseEntity<ErrorResponse> handleFileSizeLimitExceeded(FileSizeLimitExceededException ex) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(new ErrorResponse(400, ex.getMessage()));
+    }
+
     @ExceptionHandler(IllegalArgumentException.class)
     public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException ex) {
         return ResponseEntity.status(HttpStatus.BAD_REQUEST)

--- a/backend/src/main/java/com/heritage/platform/exception/TaskLockedByAnotherUserException.java
+++ b/backend/src/main/java/com/heritage/platform/exception/TaskLockedByAnotherUserException.java
@@ -1,0 +1,7 @@
+package com.heritage.platform.exception;
+
+public class TaskLockedByAnotherUserException extends RuntimeException {
+    public TaskLockedByAnotherUserException(String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/heritage/platform/model/Resource.java
+++ b/backend/src/main/java/com/heritage/platform/model/Resource.java
@@ -35,6 +35,15 @@ public class Resource {
     @Column(nullable = false)
     private ResourceStatus status;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "locked_by")
+    private User lockedBy;
+
+    private Instant lockedAt;
+
+    @Column(nullable = false)
+    private Integer reviewPriority = 0;
+
     @ManyToMany
     @JoinTable(name = "resource_tags",
         joinColumns = @JoinColumn(name = "resource_id"),
@@ -96,6 +105,12 @@ public class Resource {
     public void setCopyrightDeclaration(String copyrightDeclaration) { this.copyrightDeclaration = copyrightDeclaration; }
     public ResourceStatus getStatus() { return status; }
     public void setStatus(ResourceStatus status) { this.status = status; }
+    public User getLockedBy() { return lockedBy; }
+    public void setLockedBy(User lockedBy) { this.lockedBy = lockedBy; }
+    public Instant getLockedAt() { return lockedAt; }
+    public void setLockedAt(Instant lockedAt) { this.lockedAt = lockedAt; }
+    public Integer getReviewPriority() { return reviewPriority; }
+    public void setReviewPriority(Integer reviewPriority) { this.reviewPriority = reviewPriority; }
     public Set<Tag> getTags() { return tags; }
     public void setTags(Set<Tag> tags) { this.tags = tags; }
     public List<FileReference> getFileReferences() { return fileReferences; }

--- a/backend/src/main/java/com/heritage/platform/model/ResourceStatus.java
+++ b/backend/src/main/java/com/heritage/platform/model/ResourceStatus.java
@@ -6,13 +6,15 @@ import java.util.Set;
 public enum ResourceStatus {
     DRAFT,
     PENDING_REVIEW,
+    IN_REVIEW,
     APPROVED,
     REJECTED,
     ARCHIVED;
 
     private static final Map<ResourceStatus, Set<ResourceStatus>> ALLOWED_TRANSITIONS = Map.of(
         DRAFT, Set.of(PENDING_REVIEW),
-        PENDING_REVIEW, Set.of(APPROVED, REJECTED),
+        PENDING_REVIEW, Set.of(IN_REVIEW),
+        IN_REVIEW, Set.of(APPROVED, REJECTED, PENDING_REVIEW),
         APPROVED, Set.of(ARCHIVED, DRAFT),
         REJECTED, Set.of(DRAFT),
         ARCHIVED, Set.of(APPROVED)

--- a/backend/src/main/java/com/heritage/platform/repository/ResourceRepository.java
+++ b/backend/src/main/java/com/heritage/platform/repository/ResourceRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.UUID;
 
@@ -123,4 +124,13 @@ public interface ResourceRepository extends JpaRepository<Resource, UUID> {
             @Param("tagId") UUID tagId,
             Pageable pageable
     );
+
+    // Task allocation queries
+    Resource findFirstByStatusAndLockedByIsNullOrderByReviewPriorityDescCreatedAtAsc(ResourceStatus status);
+    
+    List<Resource> findByStatusAndLockedById(ResourceStatus status, UUID lockedById);
+    
+    List<Resource> findByStatusAndLockedByIsNull(ResourceStatus status);
+    
+    List<Resource> findByStatusAndLockedAtBefore(ResourceStatus status, Instant lockedAt);
 }

--- a/backend/src/main/java/com/heritage/platform/service/ReviewService.java
+++ b/backend/src/main/java/com/heritage/platform/service/ReviewService.java
@@ -3,6 +3,7 @@ package com.heritage.platform.service;
 import com.heritage.platform.dto.ReviewHistoryResponse;
 import com.heritage.platform.exception.InvalidStatusTransitionException;
 import com.heritage.platform.exception.ResourceNotFoundException;
+import com.heritage.platform.exception.TaskLockedByAnotherUserException;
 import com.heritage.platform.model.Resource;
 import com.heritage.platform.model.ResourceStatus;
 import com.heritage.platform.model.ReviewFeedback;
@@ -52,17 +53,19 @@ public class ReviewService {
     }
 
     /**
-     * Approves a resource. Only PENDING_REVIEW resources can be approved.
+     * Approves a resource. Supports both PENDING_REVIEW and IN_REVIEW resources.
+     * For IN_REVIEW resources, validates that the current user is the locked reviewer.
      */
     @Transactional
     public Resource approveResource(UUID resourceId, String email) {
         Resource resource = resourceRepository.findById(resourceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Resource not found"));
 
-        validatePendingReviewStatus(resource);
-
         User reviewer = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        // Validate status and lock ownership
+        validateReviewStatusAndLock(resource, reviewer);
 
         ReviewFeedback feedback = new ReviewFeedback();
         feedback.setResource(resource);
@@ -71,12 +74,16 @@ public class ReviewService {
         feedback.setDecision("APPROVED");
         reviewFeedbackRepository.save(feedback);
 
+        // Clear lock if resource was locked
+        clearResourceLock(resource);
+
         return resourceService.transitionStatus(resourceId, ResourceStatus.APPROVED, reviewer);
     }
 
     /**
      * Rejects a resource with required feedback comments.
-     * Only PENDING_REVIEW resources can be rejected.
+     * Supports both PENDING_REVIEW and IN_REVIEW resources.
+     * For IN_REVIEW resources, validates that the current user is the locked reviewer.
      */
     @Transactional
     public Resource rejectResource(UUID resourceId, String email, String comments) {
@@ -87,10 +94,11 @@ public class ReviewService {
         Resource resource = resourceRepository.findById(resourceId)
                 .orElseThrow(() -> new ResourceNotFoundException("Resource not found"));
 
-        validatePendingReviewStatus(resource);
-
         User reviewer = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        // Validate status and lock ownership
+        validateReviewStatusAndLock(resource, reviewer);
 
         ReviewFeedback feedback = new ReviewFeedback();
         feedback.setResource(resource);
@@ -99,15 +107,46 @@ public class ReviewService {
         feedback.setDecision("REJECTED");
         reviewFeedbackRepository.save(feedback);
 
+        // Clear lock if resource was locked
+        clearResourceLock(resource);
+
         return resourceService.transitionStatus(resourceId, ResourceStatus.REJECTED, reviewer);
     }
 
-    private void validatePendingReviewStatus(Resource resource) {
-        if (resource.getStatus() != ResourceStatus.PENDING_REVIEW) {
+    /**
+     * Validates that the resource can be reviewed by the current user.
+     * Supports PENDING_REVIEW (unlocked) and IN_REVIEW (locked by current user) statuses.
+     */
+    private void validateReviewStatusAndLock(Resource resource, User currentReviewer) {
+        ResourceStatus status = resource.getStatus();
+        
+        // Check if status is valid for review
+        if (status != ResourceStatus.PENDING_REVIEW && status != ResourceStatus.IN_REVIEW) {
             throw new InvalidStatusTransitionException(
-                    String.format("Resource is in %s status. Only PENDING_REVIEW resources can be reviewed.",
-                            resource.getStatus()));
+                    String.format("Resource is in %s status. Only PENDING_REVIEW or IN_REVIEW resources can be reviewed.",
+                            status));
         }
+        
+        // For IN_REVIEW resources, verify the current user is the locked reviewer
+        if (status == ResourceStatus.IN_REVIEW) {
+            if (resource.getLockedBy() == null) {
+                throw new InvalidStatusTransitionException("Resource is IN_REVIEW but not locked by any user");
+            }
+            
+            if (!resource.getLockedBy().getId().equals(currentReviewer.getId())) {
+                throw new TaskLockedByAnotherUserException(
+                        "Access denied: This task has been claimed by another user");
+            }
+        }
+    }
+
+    /**
+     * Clears the lock fields from a resource.
+     */
+    private void clearResourceLock(Resource resource) {
+        resource.setLockedBy(null);
+        resource.setLockedAt(null);
+        resourceRepository.save(resource);
     }
 
     @Transactional(readOnly = true)

--- a/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
@@ -1,0 +1,108 @@
+package com.heritage.platform.service;
+
+import com.heritage.platform.model.Resource;
+import com.heritage.platform.model.ResourceStatus;
+import com.heritage.platform.model.User;
+import com.heritage.platform.repository.ResourceRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class TaskAllocationService {
+
+    private static final long LOCK_TIMEOUT_MINUTES = 30;
+
+    @Autowired
+    private ResourceRepository resourceRepository;
+
+    /**
+     * Get next task from pool and lock it for the reviewer
+     */
+    @Transactional
+    public Resource getNextTask(UUID reviewerId) {
+        // Find the highest priority pending task that is not locked
+        Resource resource = resourceRepository
+            .findFirstByStatusAndLockedByIsNullOrderByReviewPriorityDescCreatedAtAsc(
+                ResourceStatus.PENDING_REVIEW
+            );
+
+        if (resource == null) {
+            return null;
+        }
+
+        return lockTask(resource.getId(), reviewerId);
+    }
+
+    /**
+     * Lock a task for a reviewer
+     */
+    @Transactional
+    public Resource lockTask(UUID resourceId, UUID reviewerId) {
+        Resource resource = resourceRepository.findById(resourceId)
+            .orElseThrow(() -> new RuntimeException("Resource not found"));
+
+        // Check if already locked
+        if (resource.getLockedBy() != null) {
+            throw new RuntimeException("Task is already locked by another reviewer");
+        }
+
+        // Update resource status
+        User reviewer = new User();
+        reviewer.setId(reviewerId);
+        resource.setStatus(ResourceStatus.IN_REVIEW);
+        resource.setLockedBy(reviewer);
+        resource.setLockedAt(Instant.now());
+        
+        return resourceRepository.save(resource);
+    }
+
+    /**
+     * Release a task back to the pool
+     */
+    @Transactional
+    public void releaseTask(UUID resourceId) {
+        Resource resource = resourceRepository.findById(resourceId)
+            .orElseThrow(() -> new RuntimeException("Resource not found"));
+
+        // Reset lock fields
+        resource.setLockedBy(null);
+        resource.setLockedAt(null);
+        resource.setStatus(ResourceStatus.PENDING_REVIEW);
+        resourceRepository.save(resource);
+    }
+
+    /**
+     * Get tasks assigned to a reviewer
+     */
+    @Transactional(readOnly = true)
+    public List<Resource> getAssignedTasks(UUID reviewerId) {
+        return resourceRepository.findByStatusAndLockedById(ResourceStatus.IN_REVIEW, reviewerId);
+    }
+
+    /**
+     * Release expired locks (called by scheduled task)
+     * Returns number of released tasks
+     */
+    @Transactional
+    public int releaseExpiredLocks() {
+        Instant cutoffTime = Instant.now().minus(LOCK_TIMEOUT_MINUTES, ChronoUnit.MINUTES);
+        
+        List<Resource> expiredTasks = resourceRepository
+            .findByStatusAndLockedAtBefore(ResourceStatus.IN_REVIEW, cutoffTime);
+        
+        for (Resource resource : expiredTasks) {
+            resource.setLockedBy(null);
+            resource.setLockedAt(null);
+            resource.setStatus(ResourceStatus.PENDING_REVIEW);
+            resourceRepository.save(resource);
+        }
+        
+        return expiredTasks.size();
+    }
+}

--- a/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
@@ -1,10 +1,13 @@
 package com.heritage.platform.service;
 
+import com.heritage.platform.exception.AccessDeniedException;
+import com.heritage.platform.exception.ResourceNotFoundException;
+import com.heritage.platform.exception.TaskLockedByAnotherUserException;
 import com.heritage.platform.model.Resource;
 import com.heritage.platform.model.ResourceStatus;
 import com.heritage.platform.model.User;
 import com.heritage.platform.repository.ResourceRepository;
-import org.springframework.beans.factory.annotation.Autowired;
+import com.heritage.platform.repository.UserRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,14 +21,22 @@ public class TaskAllocationService {
 
     private static final long LOCK_TIMEOUT_MINUTES = 30;
 
-    @Autowired
-    private ResourceRepository resourceRepository;
+    private final ResourceRepository resourceRepository;
+    private final UserRepository userRepository;
+
+    public TaskAllocationService(ResourceRepository resourceRepository, UserRepository userRepository) {
+        this.resourceRepository = resourceRepository;
+        this.userRepository = userRepository;
+    }
 
     /**
      * Get next task from pool and lock it for the reviewer
      */
     @Transactional
-    public Resource getNextTask(UUID reviewerId) {
+    public Resource getNextTask(String reviewerEmail) {
+        User reviewer = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
         // Find the highest priority pending task that is not locked
         Resource resource = resourceRepository
             .findFirstByStatusAndLockedByIsNullOrderByReviewPriorityDescCreatedAtAsc(
@@ -36,7 +47,7 @@ public class TaskAllocationService {
             return null;
         }
 
-        return lockTask(resource.getId(), reviewerId);
+        return lockTask(resource.getId(), reviewer.getId());
     }
 
     /**
@@ -45,16 +56,17 @@ public class TaskAllocationService {
     @Transactional
     public Resource lockTask(UUID resourceId, UUID reviewerId) {
         Resource resource = resourceRepository.findById(resourceId)
-            .orElseThrow(() -> new RuntimeException("Resource not found"));
+            .orElseThrow(() -> new ResourceNotFoundException("Resource not found"));
 
         // Check if already locked
-        if (resource.getLockedBy() != null) {
-            throw new RuntimeException("Task is already locked by another reviewer");
+        if (resource.getLockedBy() != null && !resource.getLockedBy().getId().equals(reviewerId)) {
+            throw new TaskLockedByAnotherUserException(
+                    "Access denied: This task has been claimed by another user");
         }
 
         // Update resource status
-        User reviewer = new User();
-        reviewer.setId(reviewerId);
+        User reviewer = userRepository.findById(reviewerId)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
         resource.setStatus(ResourceStatus.IN_REVIEW);
         resource.setLockedBy(reviewer);
         resource.setLockedAt(Instant.now());
@@ -66,9 +78,15 @@ public class TaskAllocationService {
      * Release a task back to the pool
      */
     @Transactional
-    public void releaseTask(UUID resourceId) {
+    public void releaseTask(UUID resourceId, String reviewerEmail) {
         Resource resource = resourceRepository.findById(resourceId)
-            .orElseThrow(() -> new RuntimeException("Resource not found"));
+            .orElseThrow(() -> new ResourceNotFoundException("Resource not found"));
+        User reviewer = userRepository.findByEmail(reviewerEmail)
+                .orElseThrow(() -> new ResourceNotFoundException("User not found"));
+
+        if (resource.getLockedBy() != null && !resource.getLockedBy().getId().equals(reviewer.getId())) {
+            throw new AccessDeniedException("You do not have permission to release this task");
+        }
 
         // Reset lock fields
         resource.setLockedBy(null);

--- a/backend/src/main/java/com/heritage/platform/service/TaskLockExpirationScheduler.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskLockExpirationScheduler.java
@@ -1,14 +1,19 @@
 package com.heritage.platform.service;
 
-import org.springframework.beans.factory.annotation.Autowired;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 @Component
 public class TaskLockExpirationScheduler {
+    private static final Logger log = LoggerFactory.getLogger(TaskLockExpirationScheduler.class);
 
-    @Autowired
-    private TaskAllocationService taskAllocationService;
+    private final TaskAllocationService taskAllocationService;
+
+    public TaskLockExpirationScheduler(TaskAllocationService taskAllocationService) {
+        this.taskAllocationService = taskAllocationService;
+    }
 
     /**
      * Check for expired locks every 1 minute
@@ -18,7 +23,7 @@ public class TaskLockExpirationScheduler {
     public void releaseExpiredLocks() {
         int releasedCount = taskAllocationService.releaseExpiredLocks();
         if (releasedCount > 0) {
-            System.out.println("Released " + releasedCount + " expired task locks");
+            log.info("Released {} expired task locks", releasedCount);
         }
     }
 }

--- a/backend/src/main/java/com/heritage/platform/service/TaskLockExpirationScheduler.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskLockExpirationScheduler.java
@@ -1,0 +1,24 @@
+package com.heritage.platform.service;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TaskLockExpirationScheduler {
+
+    @Autowired
+    private TaskAllocationService taskAllocationService;
+
+    /**
+     * Check for expired locks every 1 minute
+     * Releases tasks that have been locked for more than 30 minutes
+     */
+    @Scheduled(fixedRate = 60000) // Every 1 minute
+    public void releaseExpiredLocks() {
+        int releasedCount = taskAllocationService.releaseExpiredLocks();
+        if (releasedCount > 0) {
+            System.out.println("Released " + releasedCount + " expired task locks");
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V6__add_task_lock_fields.sql
+++ b/backend/src/main/resources/db/migration/V6__add_task_lock_fields.sql
@@ -1,0 +1,15 @@
+-- V6: Add task lock fields for review task allocation
+
+-- Add lock fields to resources table
+ALTER TABLE resources
+    ADD COLUMN locked_by BINARY(16) NULL,
+    ADD COLUMN locked_at TIMESTAMP(6) NULL,
+    ADD COLUMN review_priority INT NOT NULL DEFAULT 0,
+    ADD CONSTRAINT fk_resources_locked_by FOREIGN KEY (locked_by) REFERENCES users(id);
+
+-- Create index for efficient task pool queries
+CREATE INDEX idx_resources_status_priority_created
+    ON resources(status, review_priority DESC, created_at ASC);
+
+CREATE INDEX idx_resources_locked_by
+    ON resources(locked_by);

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -1,7 +1,9 @@
 "use client";
 
 import Link from "next/link";
-import { useQuery } from "@tanstack/react-query";
+import { useRouter } from "next/navigation";
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { useState } from "react";
 import { apiClient } from "@/lib/api-client";
 import { ProtectedRoute } from "@/components/protected-route";
 import { PageContainer } from "@/components/page-container";
@@ -11,9 +13,29 @@ import { Skeleton } from "@/components/ui/skeleton";
 import type { ResourceResponse } from "@/types";
 
 function ReviewQueueContent() {
+  const router = useRouter();
+  const [nextTaskError, setNextTaskError] = useState<string | null>(null);
+
   const queueQuery = useQuery({
     queryKey: ["review-queue"],
     queryFn: () => apiClient.get<ResourceResponse[]>("/api/reviews/queue"),
+  });
+
+  const nextTaskMutation = useMutation({
+    mutationFn: () => apiClient.post<ResourceResponse | undefined>("/api/tasks/next"),
+    onSuccess: (task) => {
+      if (!task) {
+        setNextTaskError("No available review tasks right now.");
+        return;
+      }
+      setNextTaskError(null);
+      router.push(`/review/${task.id}`);
+    },
+    onError: (error) => {
+      setNextTaskError(
+        error instanceof Error ? error.message : "Failed to get next task."
+      );
+    },
   });
 
   return (
@@ -28,6 +50,12 @@ function ReviewQueueContent() {
           </div>
 
           <div className="flex flex-wrap gap-2">
+            <Button
+              onClick={() => nextTaskMutation.mutate()}
+              disabled={nextTaskMutation.isPending}
+            >
+              {nextTaskMutation.isPending ? "Loading..." : "Get Next Task"}
+            </Button>
             <Link href="/review/history">
               <Button variant="outline">Review History</Button>
             </Link>
@@ -36,6 +64,15 @@ function ReviewQueueContent() {
             </Link>
           </div>
         </div>
+
+        {nextTaskError && (
+          <div
+            role="alert"
+            className="mb-4 rounded-md bg-destructive/10 p-3 text-sm text-destructive"
+          >
+            {nextTaskError}
+          </div>
+        )}
 
         {queueQuery.isLoading ? (
           <div className="space-y-3">

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -54,7 +54,12 @@ async function handleResponse<T>(
   }
 
   if (response.status === 403) {
-    throw new ApiError("Access denied", 403);
+    const errorBody = await response.json().catch(() => null);
+    throw new ApiError(
+      errorBody?.message ?? "Access denied",
+      403,
+      errorBody
+    );
   }
 
   if (!response.ok) {

--- a/frontend/src/lib/api-client.ts
+++ b/frontend/src/lib/api-client.ts
@@ -54,12 +54,8 @@ async function handleResponse<T>(
   }
 
   if (response.status === 403) {
-    const errorBody = await response.json().catch(() => null);
-    throw new ApiError(
-      errorBody?.message ?? "Access denied",
-      403,
-      errorBody
-    );
+    const message = await parseErrorMessage(response);
+    throw new ApiError(message || "Access denied", 403);
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## Summary
This PR integrates backend task-lock changes and aligns the review frontend flow with the new APIs.

- Merged backend task allocation / lock / release capabilities into the integration branch.
- Added and aligned review task workflow:
  - `POST /api/tasks/next` for "Get Next Task"
  - lock conflict handling and release-related behavior
- Aligned frontend with backend behavior:
  - Review queue "Get Next Task" now calls `/api/tasks/next`
  - 403 error handling now preserves backend message (e.g. claimed by another reviewer)
- Updated file size limit flow to match requirement:
  - backend file upload limit updated to 100MB
  - frontend displays backend limit error message

## PBI Coverage
- **PBI 1 (File size limit 100MB)**: Implemented (backend + frontend error display)
- **PBI 2 (Review task allocation lock)**: Implemented (backend lock flow + frontend entry action)
- **PBI 3 (Lock resource release / conflict protection)**: Implemented (backend lock release/conflict logic + frontend message mapping)

## Test Plan
- [ ] Frontend: run `npm run lint` in `frontend/`
- [ ] Backend: run compile/tests in Java 21 environment
- [ ] Click **Get Next Task** on review queue and verify navigation to assigned resource
- [ ] Verify no-task scenario returns proper empty/notice behavior
- [ ] Verify reject/approve updates queue and lock state correctly
- [ ] Verify locked-by-other-user scenario returns backend 403 message and is shown in frontend
- [ ] Verify uploading file >100MB returns expected limit error message

## Notes
- Branch is based on current `main` architecture (local/JWT/local-storage flow), not legacy AWS archive branch.
- This PR includes both corresponding backend and frontend changes for the three PBIs.