### PR TITLE
fix: deploy frontend public assets correctly

### DIFF
--- a/.github/workflows/deploy-backend.yml
+++ b/.github/workflows/deploy-backend.yml
@@ -85,9 +85,16 @@ jobs:
             sudo cp /tmp/nginx-heritage.conf /etc/nginx/sites-available/heritage
             sudo ln -sf /etc/nginx/sites-available/heritage /etc/nginx/sites-enabled/heritage
             
-            # Copy static assets into standalone directory where Next.js expects them
-            cp -r /opt/heritage/app/frontend/.next/static /opt/heritage/app/frontend/.next/standalone/.next/static
-            cp -r /opt/heritage/app/frontend/public /opt/heritage/app/frontend/.next/standalone/public
+            # Copy static assets into the standalone directory where Next.js serves them.
+            # Sync contents, not the parent directory, so repeated deploys do not create
+            # nested paths like public/public/heritage.
+            rm -rf /opt/heritage/app/frontend/.next/standalone/.next/static
+            mkdir -p /opt/heritage/app/frontend/.next/standalone/.next/static
+            cp -a /opt/heritage/app/frontend/.next/static/. /opt/heritage/app/frontend/.next/standalone/.next/static/
+
+            rm -rf /opt/heritage/app/frontend/.next/standalone/public
+            mkdir -p /opt/heritage/app/frontend/.next/standalone/public
+            cp -a /opt/heritage/app/frontend/public/. /opt/heritage/app/frontend/.next/standalone/public/
             
             sudo systemctl restart heritage-backend
             sleep 10


### PR DESCRIPTION
Fix frontend deployment so public assets are copied into the correct Next.js standalone directory.

Previously repeated deploys could nest assets under public/public, causing hero season images like /heritage/seasons/spring.webp to return Next.js 404 pages in production. The deploy workflow now clears and recreates the standalone public/static folders, then copies directory contents directly.