### PR TITLE
Update homepage feature card hover effects

### DIFF
--- a/backend/src/main/java/com/heritage/platform/dto/ResourceResponse.java
+++ b/backend/src/main/java/com/heritage/platform/dto/ResourceResponse.java
@@ -1,5 +1,6 @@
 package com.heritage.platform.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.heritage.platform.model.ExternalLink;
 import com.heritage.platform.model.FileReference;
 import com.heritage.platform.model.Resource;
@@ -131,6 +132,7 @@ public class ResourceResponse {
     public Instant getUpdatedAt() { return updatedAt; }
     public Instant getApprovedAt() { return approvedAt; }
     public List<ReviewFeedbackDto> getReviewFeedbacks() { return reviewFeedbacks; }
+    @JsonProperty("isFeatured")
     public boolean isFeatured() { return isFeatured; }
     public String getFeaturedStatus() { return featuredStatus; }
 

--- a/frontend/src/app/featured/page.tsx
+++ b/frontend/src/app/featured/page.tsx
@@ -3,7 +3,7 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { StarOff } from "lucide-react";
+import { Star, StarOff } from "lucide-react";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
 import { ProtectedRoute } from "@/components/protected-route";
@@ -27,11 +27,14 @@ function formatEnglishDate(value?: string | null) {
   });
 }
 
+function isResourceFeatured(resource: Pick<ResourceResponse, "isFeatured" | "featuredStatus">) {
+  return resource.isFeatured || resource.featuredStatus === "APPROVED";
+}
+
 function featuredStatusLabel(status?: FeaturedStatus | null, isFeatured?: boolean) {
-  if (isFeatured) return "Featured";
+  if (isFeatured || status === "APPROVED") return "Featured";
   if (!status || status === "NONE") return "Not Applied";
   if (status === "PENDING") return "Pending";
-  if (status === "APPROVED") return "Approved";
   if (status === "REJECTED") return "Rejected";
   return status;
 }
@@ -264,9 +267,10 @@ function FeaturedContent() {
                 ]}
               >
                 {myApprovedResources.map((resource) => {
+                  const alreadyFeatured = isResourceFeatured(resource);
                   const canApply =
                     resource.status === "APPROVED" &&
-                    !resource.isFeatured &&
+                    !alreadyFeatured &&
                     resource.featuredStatus !== "PENDING";
 
                   return (
@@ -280,7 +284,7 @@ function FeaturedContent() {
                           disabled={!canApply || isActing}
                           onClick={() => applyMutation.mutate(resource.id)}
                         >
-                          {resource.isFeatured || resource.featuredStatus === "APPROVED"
+                          {alreadyFeatured
                             ? "Featured"
                             : resource.featuredStatus === "PENDING"
                               ? "Application Pending"
@@ -361,7 +365,7 @@ function FeaturedContent() {
             <section>
               <SectionTitle
                 title="Manual Featured Selection"
-                helper="Manually pin approved resources to the homepage or remove them from featured placement."
+                helper="Manually pin approved resources to the homepage. Already featured resources are shown as unavailable."
               />
               {approvedResourcesQuery.isLoading ? (
                 <LoadingRows />
@@ -380,35 +384,35 @@ function FeaturedContent() {
                     ["Action", 1],
                   ]}
                 >
-                  {approvedResourcePool.map((resource) => (
-                    <TableRow key={resource.id}>
-                      <Cell span={3} title>{resource.title || "Untitled draft"}</Cell>
-                      <Cell span={2} muted>{resource.contributorName}</Cell>
-                      <Cell span={2} muted>{formatEnglishDate(resource.approvedAt)}</Cell>
-                      <Cell span={2}><StatusBadge status={resource.status} /></Cell>
-                      <Cell span={2}>{featuredStatusLabel(resource.featuredStatus, resource.isFeatured)}</Cell>
-                      <Cell span={1} right>
-                        {resource.isFeatured ? (
-                          <Button
-                            size="sm"
-                            variant="outline"
-                            disabled={isActing}
-                            onClick={() => unfeatureMutation.mutate(resource.id)}
-                          >
-                            Unfeature
-                          </Button>
-                        ) : (
-                          <Button
-                            size="sm"
-                            disabled={isActing}
-                            onClick={() => featureMutation.mutate(resource.id)}
-                          >
-                            Feature
-                          </Button>
-                        )}
-                      </Cell>
-                    </TableRow>
-                  ))}
+                  {approvedResourcePool.map((resource) => {
+                    const alreadyFeatured = isResourceFeatured(resource);
+
+                    return (
+                      <TableRow key={resource.id}>
+                        <Cell span={3} title>{resource.title || "Untitled draft"}</Cell>
+                        <Cell span={2} muted>{resource.contributorName}</Cell>
+                        <Cell span={2} muted>{formatEnglishDate(resource.approvedAt)}</Cell>
+                        <Cell span={2}><StatusBadge status={resource.status} /></Cell>
+                        <Cell span={2}>{featuredStatusLabel(resource.featuredStatus, resource.isFeatured)}</Cell>
+                        <Cell span={1} right>
+                          {alreadyFeatured ? (
+                            <Button size="sm" variant="outline" disabled>
+                              <Star className="size-3.5" />
+                              Featured
+                            </Button>
+                          ) : (
+                            <Button
+                              size="sm"
+                              disabled={isActing}
+                              onClick={() => featureMutation.mutate(resource.id)}
+                            >
+                              Feature
+                            </Button>
+                          )}
+                        </Cell>
+                      </TableRow>
+                    );
+                  })}
                 </TableCard>
               )}
             </section>

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -265,7 +265,7 @@ html {
     radial-gradient(circle at 58% 18%, rgba(255, 255, 255, 0.86) 0 1px, transparent 2px),
     radial-gradient(circle at 76% 42%, rgba(186, 230, 253, 0.68) 0 1px, transparent 2px);
   background-size: 180px 220px, 240px 260px, 210px 240px, 260px 280px;
-  opacity: 0.76;
+  opacity: 0.24;
   animation: homepage-winter-snow 11s linear infinite;
 }
 
@@ -294,12 +294,13 @@ html {
 
 .homepage-season-motion-spring::after {
   background-image:
-    radial-gradient(circle at 18% 30%, rgba(255, 236, 241, 0.72) 0 1px, transparent 2px),
-    radial-gradient(circle at 45% 22%, rgba(255, 220, 230, 0.58) 0 1px, transparent 2px),
-    radial-gradient(circle at 68% 38%, rgba(255, 238, 242, 0.62) 0 1px, transparent 2px),
-    radial-gradient(circle at 82% 18%, rgba(255, 213, 224, 0.5) 0 1px, transparent 2px);
-  background-size: 260px 220px;
-  opacity: 0.82;
+    radial-gradient(ellipse 4px 2.4px at 18% 30%, rgba(255, 240, 246, 0.86) 0 58%, transparent 68%),
+    radial-gradient(ellipse 3.6px 2.2px at 45% 22%, rgba(255, 199, 218, 0.7) 0 58%, transparent 68%),
+    radial-gradient(ellipse 4px 2.3px at 68% 38%, rgba(255, 232, 240, 0.76) 0 58%, transparent 68%),
+    radial-gradient(ellipse 3.8px 2.2px at 82% 18%, rgba(255, 190, 212, 0.66) 0 58%, transparent 68%),
+    radial-gradient(circle at 18.4% 30.2%, rgba(255, 211, 128, 0.55) 0 0.7px, transparent 1.2px);
+  background-size: 260px 220px, 260px 220px, 260px 220px, 260px 220px, 260px 220px;
+  opacity: 0.42;
   animation: homepage-petal-drift 13s linear infinite;
 }
 
@@ -309,13 +310,14 @@ html {
 
 .homepage-season-detail-spring::before {
   background-image:
-    radial-gradient(ellipse at 14% 18%, rgba(255, 239, 244, 0.82) 0 2px, transparent 4px),
-    radial-gradient(ellipse at 32% 42%, rgba(255, 211, 224, 0.72) 0 2px, transparent 4px),
-    radial-gradient(ellipse at 58% 26%, rgba(255, 245, 248, 0.76) 0 2px, transparent 4px),
-    radial-gradient(ellipse at 78% 38%, rgba(255, 203, 219, 0.66) 0 2px, transparent 4px);
-  background-size: 220px 240px, 260px 280px, 240px 260px, 280px 300px;
+    radial-gradient(ellipse 5px 3px at 14% 18%, rgba(255, 239, 246, 0.9) 0 58%, transparent 68%),
+    radial-gradient(ellipse 4.5px 2.8px at 32% 42%, rgba(255, 203, 222, 0.82) 0 58%, transparent 68%),
+    radial-gradient(ellipse 5px 3px at 58% 26%, rgba(255, 247, 250, 0.86) 0 58%, transparent 68%),
+    radial-gradient(ellipse 4.8px 2.8px at 78% 38%, rgba(255, 194, 216, 0.78) 0 58%, transparent 68%),
+    radial-gradient(circle at 32.4% 42.2%, rgba(255, 209, 122, 0.52) 0 0.8px, transparent 1.3px);
+  background-size: 220px 240px, 260px 280px, 240px 260px, 280px 300px, 260px 280px;
   filter: blur(0.2px);
-  opacity: 0.74;
+  opacity: 0.38;
   animation: homepage-petal-foreground 10s linear infinite;
 }
 
@@ -373,7 +375,7 @@ html {
     radial-gradient(circle at 62% 28%, rgba(255, 219, 151, 0.68) 0 1px, transparent 2px),
     radial-gradient(circle at 84% 46%, rgba(255, 245, 220, 0.54) 0 1px, transparent 2px);
   background-size: 190px 180px, 230px 210px, 210px 190px, 260px 230px;
-  opacity: 0.72;
+  opacity: 0.28;
   animation: homepage-summer-dust 12s linear infinite;
 }
 
@@ -400,11 +402,12 @@ html {
   background-size: 240px 210px, 260px 230px, 220px 200px, 280px 240px, auto;
   transform: translateX(-30%) skewX(-10deg);
   animation: homepage-autumn-leaves 9s linear infinite;
+  opacity: 0.34;
 }
 
 .homepage-season-detail-autumn {
   mix-blend-mode: multiply;
-  opacity: 0.78;
+  opacity: 0.5;
 }
 
 .homepage-season-detail-autumn::before {
@@ -429,6 +432,7 @@ html {
     radial-gradient(ellipse at 82% 30%, rgba(255, 207, 119, 0.7) 0 3px, transparent 5px);
   background-size: 260px 260px, 300px 310px, 240px 280px, 320px 300px;
   filter: blur(0.15px);
+  opacity: 0.36;
   animation: homepage-autumn-foreground-leaves 8s linear infinite;
 }
 
@@ -454,6 +458,292 @@ html {
 
 .homepage-marquee {
   animation: marquee 28s linear infinite;
+}
+
+.homepage-feature-card-sea,
+.homepage-feature-card-rose,
+.homepage-feature-card-jade {
+  background: #ffffff;
+  isolation: isolate;
+  transition:
+    background 520ms ease,
+    backdrop-filter 520ms ease,
+    box-shadow 520ms ease,
+    color 520ms ease,
+    transform 520ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.homepage-feature-card-rose:hover,
+.homepage-feature-card-jade:hover,
+.homepage-feature-card-sea:hover {
+  -webkit-backdrop-filter: blur(18px) saturate(1.35);
+  backdrop-filter: blur(18px) saturate(1.35);
+  transform: translateY(-2px);
+}
+
+.homepage-feature-card-sea:hover {
+  background:
+    radial-gradient(ellipse 112% 80% at 50% -18%, rgba(132, 166, 255, 0.22), transparent 62%),
+    radial-gradient(ellipse 118% 76% at 50% 118%, rgba(194, 143, 255, 0.18), transparent 64%),
+    linear-gradient(180deg, rgba(7, 15, 38, 0.78), rgba(11, 22, 56, 0.74) 48%, rgba(6, 18, 38, 0.78));
+  box-shadow:
+    inset 0 1px 0 rgba(245, 249, 255, 0.32),
+    inset 0 -1px 0 rgba(163, 196, 255, 0.16),
+    inset 18px 0 46px rgba(106, 134, 255, 0.08),
+    inset -22px 0 54px rgba(119, 231, 255, 0.06),
+    0 18px 42px rgba(7, 20, 38, 0.16);
+}
+
+.homepage-feature-card-rose:hover {
+  background:
+    radial-gradient(ellipse 112% 80% at 50% -18%, rgba(205, 150, 214, 0.2), transparent 62%),
+    radial-gradient(ellipse 118% 76% at 50% 118%, rgba(128, 164, 255, 0.12), transparent 64%),
+    linear-gradient(180deg, rgba(40, 17, 46, 0.78), rgba(61, 28, 64, 0.74) 48%, rgba(36, 19, 46, 0.78));
+  box-shadow:
+    inset 0 1px 0 rgba(250, 244, 255, 0.3),
+    inset 0 -1px 0 rgba(186, 161, 255, 0.14),
+    inset 18px 0 46px rgba(196, 103, 176, 0.07),
+    inset -22px 0 54px rgba(119, 170, 255, 0.05),
+    0 18px 42px rgba(44, 18, 50, 0.16);
+}
+
+.homepage-feature-card-jade:hover {
+  background:
+    radial-gradient(ellipse 112% 80% at 50% -18%, rgba(137, 255, 222, 0.22), transparent 62%),
+    radial-gradient(ellipse 118% 76% at 50% 118%, rgba(92, 210, 255, 0.16), transparent 64%),
+    linear-gradient(180deg, rgba(5, 38, 36, 0.78), rgba(11, 58, 54, 0.74) 48%, rgba(6, 36, 48, 0.78));
+  box-shadow:
+    inset 0 1px 0 rgba(240, 255, 249, 0.32),
+    inset 0 -1px 0 rgba(120, 239, 209, 0.16),
+    inset 18px 0 46px rgba(87, 230, 183, 0.08),
+    inset -22px 0 54px rgba(88, 210, 255, 0.06),
+    0 18px 42px rgba(8, 48, 45, 0.16);
+}
+
+.homepage-feature-card-rose::before,
+.homepage-feature-card-rose::after,
+.homepage-feature-card-jade::before,
+.homepage-feature-card-jade::after,
+.homepage-feature-card-sea::before,
+.homepage-feature-card-sea::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  z-index: 0;
+  inset: -42%;
+  opacity: 0;
+  transition: opacity 560ms ease;
+  will-change: opacity, transform;
+}
+
+.homepage-feature-card-rose::before,
+.homepage-feature-card-jade::before,
+.homepage-feature-card-sea::before {
+  filter: blur(10px) saturate(1.22);
+  -webkit-mask-image: radial-gradient(ellipse at center, #000 0 58%, rgba(0, 0, 0, 0.72) 72%, transparent 100%);
+  mask-image: radial-gradient(ellipse at center, #000 0 58%, rgba(0, 0, 0, 0.72) 72%, transparent 100%);
+  transform: scale(1.04);
+}
+
+.homepage-feature-card-sea::before {
+  background:
+    radial-gradient(ellipse 72% 64% at 16% 12%, rgba(72, 112, 255, 0.42), transparent 72%),
+    radial-gradient(ellipse 64% 58% at 84% 16%, rgba(54, 214, 255, 0.28), transparent 74%),
+    radial-gradient(ellipse 84% 72% at 70% 88%, rgba(165, 102, 255, 0.34), transparent 76%),
+    linear-gradient(180deg, rgba(4, 10, 28, 0.62), rgba(12, 23, 58, 0.48) 54%, rgba(7, 20, 38, 0.62));
+}
+
+.homepage-feature-card-rose::before {
+  background:
+    radial-gradient(ellipse 72% 64% at 16% 12%, rgba(183, 94, 182, 0.34), transparent 72%),
+    radial-gradient(ellipse 64% 58% at 84% 16%, rgba(127, 133, 255, 0.18), transparent 74%),
+    radial-gradient(ellipse 84% 72% at 70% 88%, rgba(124, 76, 190, 0.28), transparent 76%),
+    linear-gradient(180deg, rgba(36, 13, 42, 0.62), rgba(63, 29, 65, 0.48) 54%, rgba(35, 18, 45, 0.62));
+}
+
+.homepage-feature-card-jade::before {
+  background:
+    radial-gradient(ellipse 72% 64% at 16% 12%, rgba(79, 230, 174, 0.38), transparent 72%),
+    radial-gradient(ellipse 64% 58% at 84% 16%, rgba(77, 221, 255, 0.28), transparent 74%),
+    radial-gradient(ellipse 84% 72% at 70% 88%, rgba(154, 255, 191, 0.24), transparent 76%),
+    linear-gradient(180deg, rgba(4, 35, 33, 0.62), rgba(10, 62, 57, 0.48) 54%, rgba(6, 35, 47, 0.62));
+}
+
+.homepage-feature-card-rose::after,
+.homepage-feature-card-jade::after,
+.homepage-feature-card-sea::after {
+  filter: blur(10px) saturate(1.24);
+  -webkit-mask-image: linear-gradient(90deg, transparent, #000 16% 84%, transparent);
+  mask-image: linear-gradient(90deg, transparent, #000 16% 84%, transparent);
+  mix-blend-mode: screen;
+  transform: translate3d(-8%, 3%, 0) rotate(-8deg) scale(1.08);
+}
+
+.homepage-feature-card-sea::after {
+  background:
+    radial-gradient(ellipse 44% 15% at 24% 34%, rgba(246, 249, 255, 0.38), transparent 74%),
+    radial-gradient(ellipse 56% 18% at 74% 58%, rgba(116, 234, 255, 0.26), transparent 76%),
+    radial-gradient(ellipse 46% 14% at 42% 72%, rgba(202, 162, 255, 0.24), transparent 76%);
+}
+
+.homepage-feature-card-rose::after {
+  background:
+    radial-gradient(ellipse 44% 15% at 24% 34%, rgba(251, 246, 255, 0.34), transparent 74%),
+    radial-gradient(ellipse 56% 18% at 74% 58%, rgba(160, 169, 255, 0.18), transparent 76%),
+    radial-gradient(ellipse 46% 14% at 42% 72%, rgba(210, 134, 199, 0.2), transparent 76%);
+}
+
+.homepage-feature-card-jade::after {
+  background:
+    radial-gradient(ellipse 44% 15% at 24% 34%, rgba(242, 255, 249, 0.38), transparent 74%),
+    radial-gradient(ellipse 56% 18% at 74% 58%, rgba(111, 237, 255, 0.26), transparent 76%),
+    radial-gradient(ellipse 46% 14% at 42% 72%, rgba(135, 255, 196, 0.24), transparent 76%);
+}
+
+.homepage-feature-card-rose:hover::before,
+.homepage-feature-card-rose:hover::after,
+.homepage-feature-card-jade:hover::before,
+.homepage-feature-card-jade:hover::after,
+.homepage-feature-card-sea:hover::before,
+.homepage-feature-card-sea:hover::after {
+  opacity: 1;
+}
+
+.homepage-feature-card-rose:hover::before,
+.homepage-feature-card-jade:hover::before,
+.homepage-feature-card-sea:hover::before {
+  animation: homepage-sea-atmosphere 10s ease-in-out infinite alternate;
+}
+
+.homepage-feature-card-rose:hover::after,
+.homepage-feature-card-jade:hover::after,
+.homepage-feature-card-sea:hover::after {
+  animation: homepage-sea-haze 8.5s ease-in-out infinite;
+}
+
+.homepage-feature-card-sea-field {
+  pointer-events: none;
+  position: absolute;
+  z-index: 1;
+  inset: -22%;
+  opacity: 0;
+  overflow: hidden;
+  transition: opacity 620ms ease;
+  -webkit-mask-image: radial-gradient(ellipse at center, #000 0 60%, rgba(0, 0, 0, 0.78) 74%, transparent 100%);
+  mask-image: radial-gradient(ellipse at center, #000 0 60%, rgba(0, 0, 0, 0.78) 74%, transparent 100%);
+}
+
+.homepage-feature-card-sea:hover .homepage-feature-card-sea-field {
+  opacity: 1;
+}
+
+.homepage-feature-card-rose:hover .homepage-feature-card-sea-field,
+.homepage-feature-card-jade:hover .homepage-feature-card-sea-field {
+  opacity: 1;
+}
+
+.homepage-feature-card-sea-field span {
+  position: absolute;
+  border-radius: 999px;
+  opacity: 0;
+  filter: blur(14px) saturate(1.38);
+  mix-blend-mode: screen;
+  will-change: opacity, transform;
+}
+
+.homepage-feature-card-sea-field span:nth-child(1) {
+  left: -4%;
+  top: 14%;
+  width: 74%;
+  height: 30%;
+  background: radial-gradient(ellipse at center, rgba(126, 162, 255, 0.74), rgba(113, 79, 255, 0.36) 48%, transparent 74%);
+  transform: translate3d(-12%, 8%, 0) rotate(-14deg) scale(0.98);
+}
+
+.homepage-feature-card-sea-field span:nth-child(2) {
+  right: -18%;
+  top: 2%;
+  width: 70%;
+  height: 42%;
+  background: radial-gradient(ellipse at center, rgba(94, 232, 255, 0.62), rgba(58, 105, 240, 0.3) 54%, transparent 76%);
+  filter: blur(16px) saturate(1.42);
+  transform: translate3d(8%, -8%, 0) rotate(18deg) scale(0.94);
+}
+
+.homepage-feature-card-sea-field span:nth-child(3) {
+  left: 20%;
+  bottom: -10%;
+  width: 82%;
+  height: 46%;
+  background: radial-gradient(ellipse at center, rgba(209, 158, 255, 0.62), rgba(76, 138, 255, 0.3) 52%, transparent 78%);
+  filter: blur(18px) saturate(1.34);
+  transform: translate3d(10%, 10%, 0) rotate(-10deg) scale(1);
+}
+
+.homepage-feature-card-sea-field span:nth-child(4) {
+  left: 28%;
+  top: 32%;
+  width: 48%;
+  height: 20%;
+  background: radial-gradient(ellipse at center, rgba(248, 251, 255, 0.68), rgba(126, 229, 255, 0.34) 46%, transparent 72%);
+  filter: blur(10px) saturate(1.3);
+  transform: translate3d(-2%, 0, 0) rotate(-18deg) scale(0.9);
+}
+
+.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(1) {
+  background: radial-gradient(ellipse at center, rgba(211, 138, 213, 0.62), rgba(128, 80, 178, 0.32) 48%, transparent 74%);
+}
+
+.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(2) {
+  background: radial-gradient(ellipse at center, rgba(147, 165, 255, 0.44), rgba(94, 92, 188, 0.24) 54%, transparent 76%);
+}
+
+.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(3) {
+  background: radial-gradient(ellipse at center, rgba(186, 116, 222, 0.48), rgba(153, 83, 160, 0.26) 52%, transparent 78%);
+}
+
+.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(4) {
+  background: radial-gradient(ellipse at center, rgba(252, 248, 255, 0.58), rgba(189, 158, 255, 0.26) 46%, transparent 72%);
+}
+
+.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(1) {
+  background: radial-gradient(ellipse at center, rgba(101, 238, 188, 0.68), rgba(35, 150, 137, 0.36) 48%, transparent 74%);
+}
+
+.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(2) {
+  background: radial-gradient(ellipse at center, rgba(86, 229, 255, 0.62), rgba(45, 142, 191, 0.3) 54%, transparent 76%);
+}
+
+.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(3) {
+  background: radial-gradient(ellipse at center, rgba(159, 255, 190, 0.52), rgba(59, 190, 152, 0.3) 52%, transparent 78%);
+}
+
+.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(4) {
+  background: radial-gradient(ellipse at center, rgba(243, 255, 247, 0.68), rgba(123, 236, 255, 0.34) 46%, transparent 72%);
+}
+
+.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(1),
+.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(1),
+.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(1) {
+  animation: homepage-sea-ribbon-a 9.5s ease-in-out infinite;
+}
+
+.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(2),
+.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(2),
+.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(2) {
+  animation: homepage-sea-ribbon-b 12s ease-in-out infinite;
+}
+
+.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(3),
+.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(3),
+.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(3) {
+  animation: homepage-sea-ribbon-c 14s ease-in-out infinite;
+}
+
+.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(4),
+.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(4),
+.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(4) {
+  animation: homepage-sea-ribbon-d 7.8s ease-in-out infinite;
 }
 
 .homepage-wave-path-a {
@@ -534,6 +824,97 @@ html {
   }
   50% {
     transform: translateY(10px);
+  }
+}
+
+@keyframes homepage-sea-atmosphere {
+  from {
+    opacity: 0.72;
+    transform: translate3d(-2%, -2%, 0) scale(1.03);
+  }
+  to {
+    opacity: 1;
+    transform: translate3d(2%, 2%, 0) scale(1.1);
+  }
+}
+
+@keyframes homepage-sea-haze {
+  0%,
+  100% {
+    opacity: 0.48;
+    transform: translate3d(-12%, 7%, 0) rotate(-10deg) scale(1.02);
+  }
+  48% {
+    opacity: 0.84;
+    transform: translate3d(8%, -7%, 0) rotate(-1deg) scale(1.22);
+  }
+  72% {
+    opacity: 0.62;
+    transform: translate3d(-2%, 3%, 0) rotate(5deg) scale(1.12);
+  }
+}
+
+@keyframes homepage-sea-ribbon-a {
+  0%,
+  100% {
+    opacity: 0.34;
+    transform: translate3d(-17%, 11%, 0) rotate(-16deg) scale(0.94);
+  }
+  42% {
+    opacity: 0.86;
+    transform: translate3d(22%, -12%, 0) rotate(-6deg) scale(1.18);
+  }
+  68% {
+    opacity: 0.52;
+    transform: translate3d(9%, 1%, 0) rotate(-12deg) scale(1.06);
+  }
+}
+
+@keyframes homepage-sea-ribbon-b {
+  0%,
+  100% {
+    opacity: 0.28;
+    transform: translate3d(14%, -13%, 0) rotate(19deg) scale(0.9);
+  }
+  46% {
+    opacity: 0.72;
+    transform: translate3d(-18%, 14%, 0) rotate(8deg) scale(1.18);
+  }
+  74% {
+    opacity: 0.46;
+    transform: translate3d(-6%, 1%, 0) rotate(15deg) scale(1.04);
+  }
+}
+
+@keyframes homepage-sea-ribbon-c {
+  0%,
+  100% {
+    opacity: 0.26;
+    transform: translate3d(16%, 15%, 0) rotate(-11deg) scale(0.96);
+  }
+  52% {
+    opacity: 0.68;
+    transform: translate3d(-15%, -13%, 0) rotate(-2deg) scale(1.2);
+  }
+  78% {
+    opacity: 0.44;
+    transform: translate3d(-3%, 5%, 0) rotate(-13deg) scale(1.08);
+  }
+}
+
+@keyframes homepage-sea-ribbon-d {
+  0%,
+  100% {
+    opacity: 0.24;
+    transform: translate3d(-7%, 4%, 0) rotate(-19deg) scale(0.84);
+  }
+  45% {
+    opacity: 0.82;
+    transform: translate3d(19%, -15%, 0) rotate(-7deg) scale(1.24);
+  }
+  70% {
+    opacity: 0.48;
+    transform: translate3d(5%, -2%, 0) rotate(-14deg) scale(1.04);
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -621,7 +621,7 @@ html {
   animation: homepage-sea-haze 8.5s ease-in-out infinite;
 }
 
-.homepage-feature-card-sea-field {
+.homepage-feature-card-field {
   pointer-events: none;
   position: absolute;
   z-index: 1;
@@ -633,16 +633,16 @@ html {
   mask-image: radial-gradient(ellipse at center, #000 0 60%, rgba(0, 0, 0, 0.78) 74%, transparent 100%);
 }
 
-.homepage-feature-card-sea:hover .homepage-feature-card-sea-field {
+.homepage-feature-card-sea:hover .homepage-feature-card-field {
   opacity: 1;
 }
 
-.homepage-feature-card-rose:hover .homepage-feature-card-sea-field,
-.homepage-feature-card-jade:hover .homepage-feature-card-sea-field {
+.homepage-feature-card-rose:hover .homepage-feature-card-field,
+.homepage-feature-card-jade:hover .homepage-feature-card-field {
   opacity: 1;
 }
 
-.homepage-feature-card-sea-field span {
+.homepage-feature-card-field span {
   position: absolute;
   border-radius: 999px;
   opacity: 0;
@@ -651,7 +651,7 @@ html {
   will-change: opacity, transform;
 }
 
-.homepage-feature-card-sea-field span:nth-child(1) {
+.homepage-feature-card-field span:nth-child(1) {
   left: -4%;
   top: 14%;
   width: 74%;
@@ -660,7 +660,7 @@ html {
   transform: translate3d(-12%, 8%, 0) rotate(-14deg) scale(0.98);
 }
 
-.homepage-feature-card-sea-field span:nth-child(2) {
+.homepage-feature-card-field span:nth-child(2) {
   right: -18%;
   top: 2%;
   width: 70%;
@@ -670,7 +670,7 @@ html {
   transform: translate3d(8%, -8%, 0) rotate(18deg) scale(0.94);
 }
 
-.homepage-feature-card-sea-field span:nth-child(3) {
+.homepage-feature-card-field span:nth-child(3) {
   left: 20%;
   bottom: -10%;
   width: 82%;
@@ -680,7 +680,7 @@ html {
   transform: translate3d(10%, 10%, 0) rotate(-10deg) scale(1);
 }
 
-.homepage-feature-card-sea-field span:nth-child(4) {
+.homepage-feature-card-field span:nth-child(4) {
   left: 28%;
   top: 32%;
   width: 48%;
@@ -690,59 +690,59 @@ html {
   transform: translate3d(-2%, 0, 0) rotate(-18deg) scale(0.9);
 }
 
-.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(1) {
+.homepage-feature-card-rose .homepage-feature-card-field span:nth-child(1) {
   background: radial-gradient(ellipse at center, rgba(211, 138, 213, 0.62), rgba(128, 80, 178, 0.32) 48%, transparent 74%);
 }
 
-.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(2) {
+.homepage-feature-card-rose .homepage-feature-card-field span:nth-child(2) {
   background: radial-gradient(ellipse at center, rgba(147, 165, 255, 0.44), rgba(94, 92, 188, 0.24) 54%, transparent 76%);
 }
 
-.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(3) {
+.homepage-feature-card-rose .homepage-feature-card-field span:nth-child(3) {
   background: radial-gradient(ellipse at center, rgba(186, 116, 222, 0.48), rgba(153, 83, 160, 0.26) 52%, transparent 78%);
 }
 
-.homepage-feature-card-rose .homepage-feature-card-sea-field span:nth-child(4) {
+.homepage-feature-card-rose .homepage-feature-card-field span:nth-child(4) {
   background: radial-gradient(ellipse at center, rgba(252, 248, 255, 0.58), rgba(189, 158, 255, 0.26) 46%, transparent 72%);
 }
 
-.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(1) {
+.homepage-feature-card-jade .homepage-feature-card-field span:nth-child(1) {
   background: radial-gradient(ellipse at center, rgba(101, 238, 188, 0.68), rgba(35, 150, 137, 0.36) 48%, transparent 74%);
 }
 
-.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(2) {
+.homepage-feature-card-jade .homepage-feature-card-field span:nth-child(2) {
   background: radial-gradient(ellipse at center, rgba(86, 229, 255, 0.62), rgba(45, 142, 191, 0.3) 54%, transparent 76%);
 }
 
-.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(3) {
+.homepage-feature-card-jade .homepage-feature-card-field span:nth-child(3) {
   background: radial-gradient(ellipse at center, rgba(159, 255, 190, 0.52), rgba(59, 190, 152, 0.3) 52%, transparent 78%);
 }
 
-.homepage-feature-card-jade .homepage-feature-card-sea-field span:nth-child(4) {
+.homepage-feature-card-jade .homepage-feature-card-field span:nth-child(4) {
   background: radial-gradient(ellipse at center, rgba(243, 255, 247, 0.68), rgba(123, 236, 255, 0.34) 46%, transparent 72%);
 }
 
-.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(1),
-.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(1),
-.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(1) {
+.homepage-feature-card-rose:hover .homepage-feature-card-field span:nth-child(1),
+.homepage-feature-card-jade:hover .homepage-feature-card-field span:nth-child(1),
+.homepage-feature-card-sea:hover .homepage-feature-card-field span:nth-child(1) {
   animation: homepage-sea-ribbon-a 9.5s ease-in-out infinite;
 }
 
-.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(2),
-.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(2),
-.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(2) {
+.homepage-feature-card-rose:hover .homepage-feature-card-field span:nth-child(2),
+.homepage-feature-card-jade:hover .homepage-feature-card-field span:nth-child(2),
+.homepage-feature-card-sea:hover .homepage-feature-card-field span:nth-child(2) {
   animation: homepage-sea-ribbon-b 12s ease-in-out infinite;
 }
 
-.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(3),
-.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(3),
-.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(3) {
+.homepage-feature-card-rose:hover .homepage-feature-card-field span:nth-child(3),
+.homepage-feature-card-jade:hover .homepage-feature-card-field span:nth-child(3),
+.homepage-feature-card-sea:hover .homepage-feature-card-field span:nth-child(3) {
   animation: homepage-sea-ribbon-c 14s ease-in-out infinite;
 }
 
-.homepage-feature-card-rose:hover .homepage-feature-card-sea-field span:nth-child(4),
-.homepage-feature-card-jade:hover .homepage-feature-card-sea-field span:nth-child(4),
-.homepage-feature-card-sea:hover .homepage-feature-card-sea-field span:nth-child(4) {
+.homepage-feature-card-rose:hover .homepage-feature-card-field span:nth-child(4),
+.homepage-feature-card-jade:hover .homepage-feature-card-field span:nth-child(4),
+.homepage-feature-card-sea:hover .homepage-feature-card-field span:nth-child(4) {
   animation: homepage-sea-ribbon-d 7.8s ease-in-out infinite;
 }
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,6 +1,6 @@
 ﻿"use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { type CSSProperties, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { useQuery } from "@tanstack/react-query";
 import {
@@ -33,7 +33,19 @@ type HomepageStats = {
   userCount: number;
 };
 
-const seasons = [
+type SeasonKey = "spring" | "summer" | "autumn" | "winter";
+
+const seasons: {
+  key: SeasonKey;
+  label: string;
+  year: string;
+  issue: string;
+  coords: string;
+  plate: string;
+  caption: string;
+  note: string;
+  image: string;
+}[] = [
   {
     key: "spring",
     label: "Spring",
@@ -234,6 +246,10 @@ export default function Home() {
         <div
           key={`detail-${season.key}-${heroReplayKey}`}
           className={`homepage-season-detail homepage-season-detail-${season.key}`}
+        />
+        <SeasonalParticleCanvas
+          key={`particles-${season.key}-${heroReplayKey}`}
+          seasonKey={season.key}
         />
 
         <svg
@@ -456,33 +472,61 @@ export default function Home() {
               icon: Archive,
               title: "Preserve Evidence",
               text: "Upload images, documents, oral histories, and supporting context with archival clarity.",
+              hoverClass: "hover:bg-[#071426]",
+              iconClass: "border-[#285768]/35 text-[#3f6f7d]",
+              effectClass: "homepage-feature-card-sea",
             },
             {
               num: "02",
               icon: Heart,
               title: "Curate With Care",
               text: "Community reviewers protect attribution, accuracy, and publication quality before records go live.",
+              hoverClass: "",
+              iconClass: "border-[#A86F66]/40 text-[#8C5B54]",
+              effectClass: "homepage-feature-card-rose",
             },
             {
               num: "03",
               icon: Compass,
               title: "Open Discovery",
               text: "Browse featured collections, categories, and places through an editorial museum-style archive.",
+              hoverClass: "",
+              iconClass: "border-[#7F9688]/40 text-[#667C6F]",
+              effectClass: "homepage-feature-card-jade",
             },
           ].map((item) => (
-            <div key={item.title} className="group bg-white p-10 transition-colors duration-500 hover:bg-primary hover:text-white lg:p-12">
-              <div className="mb-10 flex items-start justify-between">
-                <div className="flex h-12 w-12 items-center justify-center rounded-full border border-accent/40 transition-colors duration-500 group-hover:border-accent group-hover:bg-accent">
-                  <item.icon className="h-5 w-5 text-accent transition-colors duration-500 group-hover:text-white" />
+            <div
+              key={item.title}
+              className={`group relative overflow-hidden bg-white p-10 transition-colors duration-500 hover:text-white lg:p-12 ${item.hoverClass} ${item.effectClass}`}
+            >
+              {item.effectClass ? (
+                <div className="homepage-feature-card-sea-field" aria-hidden="true">
+                  <span />
+                  <span />
+                  <span />
+                  <span />
                 </div>
-                <span className="font-serif italic text-muted-foreground" style={{ fontSize: "1.5rem" }}>
+              ) : null}
+              <div className="relative z-10 mb-10 flex items-start justify-between">
+                <div
+                  className={`flex h-12 w-12 items-center justify-center rounded-full border bg-white/70 transition-colors duration-500 group-hover:border-white/35 group-hover:bg-white/15 ${item.iconClass}`}
+                >
+                  <item.icon className="h-5 w-5 transition-colors duration-500 group-hover:text-white" />
+                </div>
+                <span
+                  className="font-serif italic text-muted-foreground transition-colors duration-500 group-hover:text-white/65"
+                  style={{ fontSize: "1.5rem" }}
+                >
                   {item.num}
                 </span>
               </div>
-              <h3 className="mb-4 font-serif" style={{ fontSize: "1.875rem", fontWeight: 500, letterSpacing: "-0.01em" }}>
+              <h3 className="relative z-10 mb-4 font-serif" style={{ fontSize: "1.875rem", fontWeight: 500, letterSpacing: "-0.01em" }}>
                 {item.title}
               </h3>
-              <p className="text-muted-foreground group-hover:text-white/70" style={{ lineHeight: 1.75, fontSize: "0.95rem" }}>
+              <p
+                className="relative z-10 text-muted-foreground transition-colors duration-500 group-hover:text-white/78"
+                style={{ lineHeight: 1.75, fontSize: "0.95rem" }}
+              >
                 {item.text}
               </p>
             </div>
@@ -821,5 +865,527 @@ function FeatureTile({
         </div>
       </article>
     </Link>
+  );
+}
+
+type SeasonalParticle = {
+  x: number;
+  y: number;
+  z: number;
+  size: number;
+  speed: number;
+  wind: number;
+  gust: number;
+  sway: number;
+  phase: number;
+  phaseB: number;
+  wobbleRate: number;
+  wobbleRateB: number;
+  rotation: number;
+  rotationSpeed: number;
+  opacity: number;
+  tint: number;
+  blur: number;
+};
+
+type ParticleConfig = {
+  minCount: number;
+  maxCount: number;
+  countWidthDivisor: number;
+  reducedCount: number;
+  size: [number, number];
+  speed: [number, number];
+  wind: [number, number];
+  opacity: [number, number];
+  blur: [number, number];
+  sway: [number, number];
+  gust: [number, number];
+  mixBlend: CSSProperties["mixBlendMode"];
+};
+
+const particleConfigs: Record<SeasonKey, ParticleConfig> = {
+  spring: {
+    minCount: 30,
+    maxCount: 58,
+    countWidthDivisor: 27,
+    reducedCount: 20,
+    size: [3.2, 6.3],
+    speed: [15, 34],
+    wind: [8, 30],
+    opacity: [0.48, 0.84],
+    blur: [0, 0.52],
+    sway: [7, 24],
+    gust: [4, 18],
+    mixBlend: "screen",
+  },
+  summer: {
+    minCount: 30,
+    maxCount: 58,
+    countWidthDivisor: 27,
+    reducedCount: 20,
+    size: [3.0, 5.9],
+    speed: [15, 34],
+    wind: [8, 30],
+    opacity: [0.42, 0.8],
+    blur: [0.18, 0.78],
+    sway: [7, 24],
+    gust: [4, 18],
+    mixBlend: "screen",
+  },
+  autumn: {
+    minCount: 30,
+    maxCount: 58,
+    countWidthDivisor: 27,
+    reducedCount: 20,
+    size: [3.1, 6.1],
+    speed: [15, 34],
+    wind: [8, 30],
+    opacity: [0.44, 0.8],
+    blur: [0, 0.5],
+    sway: [7, 24],
+    gust: [4, 18],
+    mixBlend: "soft-light",
+  },
+  winter: {
+    minCount: 34,
+    maxCount: 64,
+    countWidthDivisor: 25,
+    reducedCount: 24,
+    size: [1.8, 4.8],
+    speed: [9, 24],
+    wind: [-6, 8],
+    opacity: [0.32, 0.78],
+    blur: [0.12, 1.15],
+    sway: [5, 16],
+    gust: [1, 7],
+    mixBlend: "screen",
+  },
+};
+
+function SeasonalParticleCanvas({ seasonKey }: { seasonKey: SeasonKey }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const context = canvas.getContext("2d");
+    if (!context) return;
+    const petalCanvas = canvas;
+    const ctx = context;
+
+    let width = 0;
+    let height = 0;
+    let dpr = 1;
+    let frameId = 0;
+    let lastTime = performance.now();
+    let paused = false;
+    let particles: SeasonalParticle[] = [];
+    const config = particleConfigs[seasonKey];
+
+    const random = (min: number, max: number) =>
+      min + Math.random() * (max - min);
+
+    function createParticle(initial = false): SeasonalParticle {
+      const z = Math.random();
+      const size = random(config.size[0], config.size[1]) + z * 1.6;
+
+      return {
+        x: random(-width * 0.2, width * 1.08),
+        y: initial
+          ? random(-height * 0.18, height * 1.08)
+          : random(-height * 0.24, -20),
+        z,
+        size,
+        speed: random(config.speed[0], config.speed[1]) + z * 18,
+        wind: random(config.wind[0], config.wind[1]) + z * 18,
+        gust: random(config.gust[0], config.gust[1]),
+        sway: random(config.sway[0], config.sway[1]) + z * 12,
+        phase: random(0, Math.PI * 2),
+        phaseB: random(0, Math.PI * 2),
+        wobbleRate: random(0.45, 1.8),
+        wobbleRateB: random(0.22, 1.15),
+        rotation: random(0, Math.PI * 2),
+        rotationSpeed: random(-1.7, 1.7) * (0.35 + z),
+        opacity: random(config.opacity[0], config.opacity[1]),
+        tint: Math.random(),
+        blur: random(config.blur[0], config.blur[1]) * (0.5 + z),
+      };
+    }
+
+    function resize() {
+      const rect = petalCanvas.getBoundingClientRect();
+      width = rect.width;
+      height = rect.height;
+      dpr = Math.min(window.devicePixelRatio || 1, 1.35);
+
+      petalCanvas.width = Math.max(1, Math.floor(width * dpr));
+      petalCanvas.height = Math.max(1, Math.floor(height * dpr));
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+      const targetCount = reducedMotion.matches
+        ? config.reducedCount
+        : Math.min(
+            config.maxCount,
+            Math.max(config.minCount, Math.floor(width / config.countWidthDivisor))
+          );
+      particles = Array.from({ length: targetCount }, () => createParticle(true));
+    }
+
+    function drawSpringPetal(particle: SeasonalParticle, time: number) {
+      const flutter = Math.sin(time * 0.002 + particle.phase);
+      const flip = 0.55 + Math.abs(Math.sin(time * 0.003 + particle.phaseB)) * 0.7;
+      const s = particle.size;
+
+      ctx.save();
+      ctx.globalAlpha = particle.opacity;
+      ctx.translate(particle.x, particle.y);
+      ctx.rotate(particle.rotation + flutter * 0.45);
+      ctx.scale(flip, 1);
+      ctx.filter = particle.blur > 0.28 && particle.z > 0.72
+        ? `blur(${particle.blur}px)`
+        : "none";
+
+      ctx.fillStyle = particle.tint > 0.55
+        ? "rgba(255, 198, 218, 0.92)"
+        : "rgba(255, 238, 246, 0.94)";
+      ctx.strokeStyle = "rgba(255, 255, 255, 0.48)";
+      ctx.lineWidth = 0.45;
+
+      ctx.beginPath();
+      ctx.moveTo(0, -s * 0.95);
+      ctx.bezierCurveTo(s * 0.72, -s * 0.58, s * 0.68, s * 0.42, 0, s);
+      ctx.bezierCurveTo(-s * 0.62, s * 0.34, -s * 0.72, -s * 0.55, 0, -s * 0.95);
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+
+      ctx.globalAlpha = particle.opacity * 0.5;
+      ctx.fillStyle = "rgba(255, 214, 132, 0.72)";
+      ctx.beginPath();
+      ctx.arc(0, s * 0.2, Math.max(0.45, s * 0.12), 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawSummerMote(particle: SeasonalParticle) {
+      const radius = particle.size * (0.26 + particle.z * 0.16);
+      const glow = radius * (2.5 + particle.z * 1.2);
+      const streak = particle.size * (0.7 + particle.z * 0.5);
+
+      ctx.save();
+      ctx.globalAlpha = particle.opacity;
+      ctx.translate(particle.x, particle.y);
+      ctx.rotate(particle.rotation * 0.45);
+      ctx.filter = particle.z > 0.72 ? `blur(${particle.blur}px)` : "none";
+      const gradient = ctx.createRadialGradient(
+        0,
+        0,
+        0,
+        0,
+        0,
+        glow
+      );
+      gradient.addColorStop(0, "rgba(255, 246, 184, 0.88)");
+      gradient.addColorStop(0.36, "rgba(255, 210, 94, 0.4)");
+      gradient.addColorStop(1, "rgba(255, 204, 105, 0)");
+      ctx.fillStyle = gradient;
+      ctx.beginPath();
+      ctx.arc(0, 0, glow, 0, Math.PI * 2);
+      ctx.fill();
+
+      ctx.filter = "none";
+      ctx.strokeStyle = "rgba(255, 246, 196, 0.58)";
+      ctx.lineWidth = Math.max(0.45, radius * 0.38);
+      ctx.lineCap = "round";
+      ctx.beginPath();
+      ctx.moveTo(-streak * 0.28, -streak * 0.12);
+      ctx.lineTo(streak * 0.28, streak * 0.12);
+      ctx.stroke();
+
+      ctx.fillStyle = particle.tint > 0.5
+        ? "rgba(255, 249, 216, 0.86)"
+        : "rgba(255, 220, 122, 0.78)";
+      ctx.beginPath();
+      ctx.arc(0, 0, radius, 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawAutumnMaple(particle: SeasonalParticle) {
+      const s = particle.size * 1.08;
+      const leafPoints: [number, number][] = [
+        [0, -1.12],
+        [-0.08, -0.82],
+        [-0.18, -0.98],
+        [-0.2, -0.68],
+        [-0.36, -0.9],
+        [-0.34, -0.58],
+        [-0.56, -0.75],
+        [-0.46, -0.46],
+        [-0.78, -0.5],
+        [-0.55, -0.28],
+        [-0.86, -0.18],
+        [-0.54, -0.1],
+        [-0.68, 0.14],
+        [-0.38, 0.04],
+        [-0.4, 0.3],
+        [-0.18, 0.18],
+        [-0.08, 0.42],
+        [0, 0.24],
+        [0.08, 0.42],
+        [0.18, 0.18],
+        [0.4, 0.3],
+        [0.38, 0.04],
+        [0.68, 0.14],
+        [0.54, -0.1],
+        [0.86, -0.18],
+        [0.55, -0.28],
+        [0.78, -0.5],
+        [0.46, -0.46],
+        [0.56, -0.75],
+        [0.34, -0.58],
+        [0.36, -0.9],
+        [0.2, -0.68],
+        [0.18, -0.98],
+        [0.08, -0.82],
+      ];
+
+      ctx.save();
+      ctx.globalAlpha = particle.opacity;
+      ctx.translate(particle.x, particle.y);
+      ctx.rotate(particle.rotation);
+      ctx.filter = particle.blur > 0.25 && particle.z > 0.75
+        ? `blur(${particle.blur}px)`
+        : "none";
+      ctx.fillStyle = particle.tint > 0.66
+        ? "rgba(190, 63, 35, 0.88)"
+        : particle.tint > 0.33
+          ? "rgba(225, 46, 42, 0.86)"
+          : "rgba(242, 105, 54, 0.82)";
+      ctx.strokeStyle = "rgba(116, 25, 28, 0.32)";
+      ctx.lineWidth = 0.36;
+
+      ctx.beginPath();
+      leafPoints.forEach(([x, y], index) => {
+        if (index === 0) {
+          ctx.moveTo(x * s, y * s);
+        } else {
+          ctx.lineTo(x * s, y * s);
+        }
+      });
+      ctx.closePath();
+      ctx.fill();
+      ctx.stroke();
+
+      const veinOriginY = s * 0.22;
+
+      ctx.globalAlpha = particle.opacity * 0.5;
+      ctx.strokeStyle = "rgba(255, 176, 132, 0.58)";
+      ctx.lineWidth = 0.34;
+      ctx.beginPath();
+      ctx.moveTo(0, veinOriginY);
+      ctx.lineTo(0, -s * 0.92);
+      [
+        [-0.18, -0.8],
+        [-0.36, -0.7],
+        [-0.58, -0.48],
+        [-0.66, -0.16],
+        [-0.28, 0.16],
+        [0.28, 0.16],
+        [0.66, -0.16],
+        [0.58, -0.48],
+        [0.36, -0.7],
+        [0.18, -0.8],
+      ].forEach(([x, y]) => {
+        ctx.moveTo(0, veinOriginY);
+        ctx.lineTo(x * s, y * s);
+      });
+      ctx.stroke();
+
+      ctx.globalAlpha = particle.opacity * 0.64;
+      ctx.strokeStyle = "rgba(126, 16, 38, 0.62)";
+      ctx.lineWidth = 0.55;
+      ctx.beginPath();
+      ctx.moveTo(0, s * 0.24);
+      ctx.bezierCurveTo(-s * 0.03, s * 0.44, -s * 0.05, s * 0.66, -s * 0.08, s * 0.94);
+      ctx.stroke();
+      ctx.restore();
+    }
+
+    function drawWinterSnow(particle: SeasonalParticle) {
+      const s = particle.size;
+      const crystalline = particle.z > 0.78 && particle.tint > 0.58;
+
+      ctx.save();
+      ctx.globalAlpha = particle.opacity;
+      ctx.translate(particle.x, particle.y);
+      ctx.rotate(particle.rotation);
+      ctx.filter = particle.blur > 0.4 && particle.z > 0.74
+        ? `blur(${particle.blur}px)`
+        : "none";
+
+      if (!crystalline) {
+        const radius = Math.max(0.7, s * (0.28 + particle.z * 0.2));
+        const glow = radius * (2.4 + particle.z * 1.8);
+        const gradient = ctx.createRadialGradient(0, 0, 0, 0, 0, glow);
+        gradient.addColorStop(0, "rgba(255, 255, 255, 0.92)");
+        gradient.addColorStop(0.38, "rgba(235, 249, 255, 0.52)");
+        gradient.addColorStop(1, "rgba(235, 249, 255, 0)");
+
+        ctx.fillStyle = gradient;
+        ctx.beginPath();
+        ctx.arc(0, 0, glow, 0, Math.PI * 2);
+        ctx.fill();
+
+        ctx.filter = "none";
+        ctx.globalAlpha = particle.opacity * 0.74;
+        ctx.fillStyle = "rgba(249, 253, 255, 0.86)";
+        ctx.beginPath();
+        ctx.arc(0, 0, radius, 0, Math.PI * 2);
+        ctx.fill();
+        ctx.restore();
+        return;
+      }
+
+      ctx.globalAlpha = particle.opacity * 0.7;
+      ctx.strokeStyle = "rgba(246, 253, 255, 0.84)";
+      ctx.lineWidth = Math.max(0.36, s * 0.075);
+      ctx.lineCap = "round";
+      ctx.lineJoin = "round";
+
+      for (let i = 0; i < 6; i += 1) {
+        ctx.save();
+        ctx.rotate((Math.PI * 2 * i) / 6);
+
+        ctx.beginPath();
+        ctx.moveTo(0, 0);
+        ctx.lineTo(0, -s * 0.88);
+        ctx.stroke();
+
+        ctx.beginPath();
+        ctx.moveTo(0, -s * 0.48);
+        ctx.lineTo(-s * 0.14, -s * 0.64);
+        ctx.moveTo(0, -s * 0.48);
+        ctx.lineTo(s * 0.14, -s * 0.64);
+        ctx.moveTo(0, -s * 0.68);
+        ctx.lineTo(-s * 0.1, -s * 0.8);
+        ctx.moveTo(0, -s * 0.68);
+        ctx.lineTo(s * 0.1, -s * 0.8);
+        ctx.stroke();
+
+        ctx.restore();
+      }
+
+      ctx.globalAlpha = particle.opacity * 0.42;
+      ctx.strokeStyle = "rgba(216, 243, 255, 0.42)";
+      ctx.lineWidth = Math.max(0.3, s * 0.05);
+      ctx.beginPath();
+      ctx.arc(0, 0, s * 0.36, 0, Math.PI * 2);
+      ctx.stroke();
+
+      ctx.fillStyle = "rgba(255, 255, 255, 0.86)";
+      ctx.beginPath();
+      ctx.arc(0, 0, Math.max(0.45, s * 0.1), 0, Math.PI * 2);
+      ctx.fill();
+      ctx.restore();
+    }
+
+    function drawParticle(particle: SeasonalParticle, time: number) {
+      if (seasonKey === "spring") {
+        drawSpringPetal(particle, time);
+      } else if (seasonKey === "summer") {
+        drawSummerMote(particle);
+      } else if (seasonKey === "autumn") {
+        drawAutumnMaple(particle);
+      } else {
+        drawWinterSnow(particle);
+      }
+    }
+
+    function resetParticle(particle: SeasonalParticle) {
+      Object.assign(particle, createParticle(false));
+      particle.x = random(-width * 0.22, width * 0.72);
+    }
+
+    function animate(now: number) {
+      if (paused) {
+        lastTime = now;
+        frameId = window.requestAnimationFrame(animate);
+        return;
+      }
+
+      const delta = Math.min(48, now - lastTime) / 1000;
+      lastTime = now;
+
+      ctx.clearRect(0, 0, width, height);
+
+      for (const particle of particles) {
+        particle.phase += delta * particle.wobbleRate;
+        particle.phaseB += delta * particle.wobbleRateB;
+        particle.rotation += particle.rotationSpeed * delta;
+
+        const gust =
+          Math.sin(now * 0.00034 + particle.phaseB) * particle.gust +
+          Math.sin(now * 0.00017 + particle.phase + particle.y * 0.012) *
+            particle.gust *
+            0.55;
+
+        particle.x +=
+          (particle.wind + gust + Math.sin(particle.phase) * particle.sway * 0.08) *
+          delta;
+        particle.y +=
+          (particle.speed + Math.cos(particle.phaseB) * particle.sway * 0.08) *
+          delta;
+
+        const displayX =
+          particle.x +
+          Math.sin(particle.phase) * particle.sway +
+          Math.sin(particle.phaseB * 1.37) * particle.sway * 0.45;
+        const displayY =
+          particle.y + Math.cos(particle.phaseB) * particle.sway * 0.18;
+
+        const savedX = particle.x;
+        const savedY = particle.y;
+        particle.x = displayX;
+        particle.y = displayY;
+        drawParticle(particle, now);
+        particle.x = savedX;
+        particle.y = savedY;
+
+        const outOfBounds =
+          particle.y > height + 42 || particle.x > width + 96;
+
+        if (outOfBounds) {
+          resetParticle(particle);
+        }
+      }
+
+      frameId = window.requestAnimationFrame(animate);
+    }
+
+    resize();
+    window.addEventListener("resize", resize);
+    const handleVisibilityChange = () => {
+      paused = document.hidden;
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    frameId = window.requestAnimationFrame(animate);
+
+    return () => {
+      window.cancelAnimationFrame(frameId);
+      window.removeEventListener("resize", resize);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  }, [seasonKey]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      aria-hidden
+      className="pointer-events-none absolute inset-0 z-[6] h-full w-full"
+      style={{ mixBlendMode: particleConfigs[seasonKey].mixBlend }}
+    />
   );
 }

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -500,7 +500,7 @@ export default function Home() {
               className={`group relative overflow-hidden bg-white p-10 transition-colors duration-500 hover:text-white lg:p-12 ${item.hoverClass} ${item.effectClass}`}
             >
               {item.effectClass ? (
-                <div className="homepage-feature-card-sea-field" aria-hidden="true">
+                <div className="homepage-feature-card-field" aria-hidden="true">
                   <span />
                   <span />
                   <span />

--- a/frontend/src/components/site-footer.tsx
+++ b/frontend/src/components/site-footer.tsx
@@ -21,7 +21,7 @@ const archiveLinks: FooterLink[] = [
 
 const communityLinks: FooterLink[] = [
   { label: "Browse Comments", href: "/my-comments" },
-  { label: "Contributor Profiles", href: "/profile" },
+  { label: "My Profile", href: "/profile" },
   {
     label: "Add Draft",
     href: "/contribute/new",

--- a/frontend/src/components/site-footer.tsx
+++ b/frontend/src/components/site-footer.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { Archive } from "lucide-react";
 import { useAuth } from "@/lib/auth-context";
 import type { UserRole } from "@/types";
+import type { MouseEvent } from "react";
 
 type FooterLink = {
   label: string;
@@ -20,7 +21,7 @@ const archiveLinks: FooterLink[] = [
 
 const communityLinks: FooterLink[] = [
   { label: "Browse Comments", href: "/my-comments" },
-  { label: "Contributor Profiles", href: "/browse" },
+  { label: "Contributor Profiles", href: "/profile" },
   {
     label: "Add Draft",
     href: "/contribute/new",
@@ -60,10 +61,18 @@ function FooterColumn({
   links: FooterLink[];
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const { user } = useAuth();
 
   function handleRestrictedClick() {
     router.push("/#site-footer");
+  }
+
+  function handleFooterLinkClick(event: MouseEvent<HTMLAnchorElement>, href: string) {
+    if (pathname !== href) return;
+
+    event.preventDefault();
+    window.scrollTo({ top: 0, behavior: "smooth" });
   }
 
   return (
@@ -86,6 +95,7 @@ function FooterColumn({
               {allowed ? (
                 <Link
                   href={link.href}
+                  onClick={(event) => handleFooterLinkClick(event, link.href)}
                   className="transition-colors hover:text-accent"
                 >
                   {link.label}


### PR DESCRIPTION
## Summary

- Updated homepage feature cards to keep a clean white default state.
- Added glass-like luminous hover effects for Preserve Evidence, Curate With Care, and Open Discovery.
- Tuned Curate With Care colors to better balance visually with the neighboring cards.

## Details

- Preserve Evidence uses a deep blue-violet luminous glass effect.
- Curate With Care uses a more balanced smoky rose-purple/lavender palette.
- Open Discovery uses a deep jade/cyan luminous glass effect.
- Hover light fields only activate on pointer hover, preventing default-state color bleed.