### PR TITLE
feat(resources): polish featured and review workflows

### DIFF
--- a/backend/src/main/java/com/heritage/platform/dto/ResourceResponse.java
+++ b/backend/src/main/java/com/heritage/platform/dto/ResourceResponse.java
@@ -190,6 +190,7 @@ public class ResourceResponse {
         private UUID id;
         private UUID resourceId;
         private UUID reviewerId;
+        private String reviewerName;
         private String comments;
         private String decision;
         private Instant createdAt;
@@ -199,6 +200,7 @@ public class ResourceResponse {
             dto.id = rf.getId();
             dto.resourceId = rf.getResource().getId();
             dto.reviewerId = rf.getReviewer().getId();
+            dto.reviewerName = rf.getReviewer().getDisplayName();
             dto.comments = rf.getComments();
             dto.decision = rf.getDecision();
             dto.createdAt = rf.getCreatedAt();
@@ -208,6 +210,7 @@ public class ResourceResponse {
         public UUID getId() { return id; }
         public UUID getResourceId() { return resourceId; }
         public UUID getReviewerId() { return reviewerId; }
+        public String getReviewerName() { return reviewerName; }
         public String getComments() { return comments; }
         public String getDecision() { return decision; }
         public Instant getCreatedAt() { return createdAt; }

--- a/backend/src/main/java/com/heritage/platform/repository/ResourceRepository.java
+++ b/backend/src/main/java/com/heritage/platform/repository/ResourceRepository.java
@@ -19,6 +19,8 @@ public interface ResourceRepository extends JpaRepository<Resource, UUID> {
 
     List<Resource> findByContributorId(UUID contributorId);
 
+    List<Resource> findByContributorIdOrderByUpdatedAtDesc(UUID contributorId);
+
     List<Resource> findByStatusOrderByCreatedAtAsc(ResourceStatus status);
 
     List<Resource> findByStatusOrderByApprovedAtDesc(ResourceStatus status);

--- a/backend/src/main/java/com/heritage/platform/service/AdminService.java
+++ b/backend/src/main/java/com/heritage/platform/service/AdminService.java
@@ -47,6 +47,13 @@ public class AdminService {
         User admin = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
+        ReviewFeedback feedback = new ReviewFeedback();
+        feedback.setResource(resource);
+        feedback.setReviewer(admin);
+        feedback.setComments("This resource has been archived by admin");
+        feedback.setDecision("ARCHIVED");
+        reviewFeedbackRepository.save(feedback);
+
         return resourceService.transitionStatus(resourceId, ResourceStatus.ARCHIVED, admin);
     }
 
@@ -68,15 +75,14 @@ public class AdminService {
         User admin = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
-        // Record the reason as review feedback
-        if (reason != null && !reason.isBlank()) {
-            ReviewFeedback feedback = new ReviewFeedback();
-            feedback.setResource(resource);
-            feedback.setReviewer(admin);
-            feedback.setComments(reason);
-            feedback.setDecision("UNPUBLISHED");
-            reviewFeedbackRepository.save(feedback);
-        }
+        ReviewFeedback feedback = new ReviewFeedback();
+        feedback.setResource(resource);
+        feedback.setReviewer(admin);
+        feedback.setComments(reason != null && !reason.isBlank()
+                ? reason
+                : "This resource has been unpublished by admin");
+        feedback.setDecision("UNPUBLISHED");
+        reviewFeedbackRepository.save(feedback);
 
         return resourceService.transitionStatus(resourceId, ResourceStatus.DRAFT, admin);
     }
@@ -112,7 +118,14 @@ public class AdminService {
             if (r.getTags() != null) r.getTags().size();
             if (r.getFileReferences() != null) r.getFileReferences().size();
             if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) r.getReviewFeedbacks().size();
+            if (r.getReviewFeedbacks() != null) {
+                r.getReviewFeedbacks().size();
+                r.getReviewFeedbacks().forEach(feedback -> {
+                    if (feedback.getReviewer() != null) {
+                        feedback.getReviewer().getDisplayName();
+                    }
+                });
+            }
             if (r.getContributor() != null) r.getContributor().getDisplayName();
         });
         return resources;

--- a/backend/src/main/java/com/heritage/platform/service/AdminService.java
+++ b/backend/src/main/java/com/heritage/platform/service/AdminService.java
@@ -50,7 +50,7 @@ public class AdminService {
         ReviewFeedback feedback = new ReviewFeedback();
         feedback.setResource(resource);
         feedback.setReviewer(admin);
-        feedback.setComments("This resource has been archived by admin");
+        feedback.setComments("");
         feedback.setDecision("ARCHIVED");
         reviewFeedbackRepository.save(feedback);
 
@@ -78,9 +78,7 @@ public class AdminService {
         ReviewFeedback feedback = new ReviewFeedback();
         feedback.setResource(resource);
         feedback.setReviewer(admin);
-        feedback.setComments(reason != null && !reason.isBlank()
-                ? reason
-                : "This resource has been unpublished by admin");
+        feedback.setComments(reason != null && !reason.isBlank() ? reason : "");
         feedback.setDecision("UNPUBLISHED");
         reviewFeedbackRepository.save(feedback);
 
@@ -113,21 +111,7 @@ public class AdminService {
     @Transactional(readOnly = true)
     public List<Resource> getArchivedResources() {
         List<Resource> resources = resourceRepository.findByStatusOrderByCreatedAtAsc(ResourceStatus.ARCHIVED);
-        resources.forEach(r -> {
-            if (r.getCategory() != null) r.getCategory().getName();
-            if (r.getTags() != null) r.getTags().size();
-            if (r.getFileReferences() != null) r.getFileReferences().size();
-            if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) {
-                r.getReviewFeedbacks().size();
-                r.getReviewFeedbacks().forEach(feedback -> {
-                    if (feedback.getReviewer() != null) {
-                        feedback.getReviewer().getDisplayName();
-                    }
-                });
-            }
-            if (r.getContributor() != null) r.getContributor().getDisplayName();
-        });
+        resources.forEach(resourceService::initializeLazyAssociations);
         return resources;
     }
 }

--- a/backend/src/main/java/com/heritage/platform/service/ResourceService.java
+++ b/backend/src/main/java/com/heritage/platform/service/ResourceService.java
@@ -167,7 +167,10 @@ public class ResourceService {
 
         validateOwnership(resource, user);
 
-        initializeLazyAssociations(resource);
+        if (resource.getStatus() != ResourceStatus.DRAFT) {
+            throw new IllegalStateException("Only DRAFT resources can be deleted");
+        }
+
         resourceRepository.delete(resource);
     }
 
@@ -368,7 +371,7 @@ public class ResourceService {
         return saved;
     }
 
-    private void initializeLazyAssociations(Resource resource) {
+    public void initializeLazyAssociations(Resource resource) {
         if (resource.getCategory() != null) {
             resource.getCategory().getName();
         }

--- a/backend/src/main/java/com/heritage/platform/service/ResourceService.java
+++ b/backend/src/main/java/com/heritage/platform/service/ResourceService.java
@@ -167,10 +167,7 @@ public class ResourceService {
 
         validateOwnership(resource, user);
 
-        if (resource.getStatus() != ResourceStatus.DRAFT) {
-            throw new IllegalStateException("Only DRAFT resources can be deleted");
-        }
-
+        initializeLazyAssociations(resource);
         resourceRepository.delete(resource);
     }
 
@@ -179,7 +176,7 @@ public class ResourceService {
         User user = userRepository.findByEmail(email)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
-        List<Resource> resources = resourceRepository.findByContributorId(user.getId());
+        List<Resource> resources = resourceRepository.findByContributorIdOrderByUpdatedAtDesc(user.getId());
         resources.forEach(this::initializeLazyAssociations);
         return resources;
     }
@@ -384,8 +381,19 @@ public class ResourceService {
         if (resource.getFileReferences() != null) {
             resource.getFileReferences().size();
         }
+        if (resource.getComments() != null) {
+            resource.getComments().size();
+        }
+        if (resource.getStatusTransitions() != null) {
+            resource.getStatusTransitions().size();
+        }
         if (resource.getReviewFeedbacks() != null) {
             resource.getReviewFeedbacks().size();
+            resource.getReviewFeedbacks().forEach(feedback -> {
+                if (feedback.getReviewer() != null) {
+                    feedback.getReviewer().getDisplayName();
+                }
+            });
         }
         if (resource.getContributor() != null) {
             resource.getContributor().getDisplayName();

--- a/backend/src/main/java/com/heritage/platform/service/ReviewService.java
+++ b/backend/src/main/java/com/heritage/platform/service/ReviewService.java
@@ -47,21 +47,7 @@ public class ReviewService {
         List<Resource> resources = new java.util.ArrayList<>(pending);
         resources.addAll(inReview);
 
-        resources.forEach(r -> {
-            if (r.getCategory() != null) r.getCategory().getName();
-            if (r.getTags() != null) r.getTags().size();
-            if (r.getFileReferences() != null) r.getFileReferences().size();
-            if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) {
-                r.getReviewFeedbacks().size();
-                r.getReviewFeedbacks().forEach(feedback -> {
-                    if (feedback.getReviewer() != null) {
-                        feedback.getReviewer().getDisplayName();
-                    }
-                });
-            }
-            if (r.getContributor() != null) r.getContributor().getDisplayName();
-        });
+        resources.forEach(resourceService::initializeLazyAssociations);
         return resources;
     }
 

--- a/backend/src/main/java/com/heritage/platform/service/ReviewService.java
+++ b/backend/src/main/java/com/heritage/platform/service/ReviewService.java
@@ -52,7 +52,14 @@ public class ReviewService {
             if (r.getTags() != null) r.getTags().size();
             if (r.getFileReferences() != null) r.getFileReferences().size();
             if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) r.getReviewFeedbacks().size();
+            if (r.getReviewFeedbacks() != null) {
+                r.getReviewFeedbacks().size();
+                r.getReviewFeedbacks().forEach(feedback -> {
+                    if (feedback.getReviewer() != null) {
+                        feedback.getReviewer().getDisplayName();
+                    }
+                });
+            }
             if (r.getContributor() != null) r.getContributor().getDisplayName();
         });
         return resources;

--- a/backend/src/main/java/com/heritage/platform/service/SearchService.java
+++ b/backend/src/main/java/com/heritage/platform/service/SearchService.java
@@ -64,7 +64,14 @@ public class SearchService {
             if (r.getTags() != null) r.getTags().size();
             if (r.getFileReferences() != null) r.getFileReferences().size();
             if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) r.getReviewFeedbacks().size();
+            if (r.getReviewFeedbacks() != null) {
+                r.getReviewFeedbacks().size();
+                r.getReviewFeedbacks().forEach(feedback -> {
+                    if (feedback.getReviewer() != null) {
+                        feedback.getReviewer().getDisplayName();
+                    }
+                });
+            }
             if (r.getContributor() != null) r.getContributor().getDisplayName();
         });
 

--- a/backend/src/main/java/com/heritage/platform/service/SearchService.java
+++ b/backend/src/main/java/com/heritage/platform/service/SearchService.java
@@ -18,9 +18,11 @@ public class SearchService {
     private static final int DEFAULT_PAGE_SIZE = 20;
 
     private final ResourceRepository resourceRepository;
+    private final ResourceService resourceService;
 
-    public SearchService(ResourceRepository resourceRepository) {
+    public SearchService(ResourceRepository resourceRepository, ResourceService resourceService) {
         this.resourceRepository = resourceRepository;
+        this.resourceService = resourceService;
     }
 
     /**
@@ -58,22 +60,7 @@ public class SearchService {
             result = resourceRepository.findByStatus(status, pageable);
         }
 
-        // Force-initialize lazy associations to prevent LazyInitializationException in DTO conversion
-        result.getContent().forEach(r -> {
-            if (r.getCategory() != null) r.getCategory().getName();
-            if (r.getTags() != null) r.getTags().size();
-            if (r.getFileReferences() != null) r.getFileReferences().size();
-            if (r.getExternalLinks() != null) r.getExternalLinks().size();
-            if (r.getReviewFeedbacks() != null) {
-                r.getReviewFeedbacks().size();
-                r.getReviewFeedbacks().forEach(feedback -> {
-                    if (feedback.getReviewer() != null) {
-                        feedback.getReviewer().getDisplayName();
-                    }
-                });
-            }
-            if (r.getContributor() != null) r.getContributor().getDisplayName();
-        });
+        result.getContent().forEach(resourceService::initializeLazyAssociations);
 
         return result;
     }

--- a/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
@@ -78,7 +78,14 @@ public class TaskAllocationService {
         if (saved.getTags() != null) saved.getTags().size();
         if (saved.getFileReferences() != null) saved.getFileReferences().size();
         if (saved.getExternalLinks() != null) saved.getExternalLinks().size();
-        if (saved.getReviewFeedbacks() != null) saved.getReviewFeedbacks().size();
+        if (saved.getReviewFeedbacks() != null) {
+            saved.getReviewFeedbacks().size();
+            saved.getReviewFeedbacks().forEach(feedback -> {
+                if (feedback.getReviewer() != null) {
+                    feedback.getReviewer().getDisplayName();
+                }
+            });
+        }
         if (saved.getContributor() != null) saved.getContributor().getDisplayName();
 
         return saved;

--- a/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
+++ b/backend/src/main/java/com/heritage/platform/service/TaskAllocationService.java
@@ -23,10 +23,12 @@ public class TaskAllocationService {
 
     private final ResourceRepository resourceRepository;
     private final UserRepository userRepository;
+    private final ResourceService resourceService;
 
-    public TaskAllocationService(ResourceRepository resourceRepository, UserRepository userRepository) {
+    public TaskAllocationService(ResourceRepository resourceRepository, UserRepository userRepository, ResourceService resourceService) {
         this.resourceRepository = resourceRepository;
         this.userRepository = userRepository;
+        this.resourceService = resourceService;
     }
 
     /**
@@ -73,20 +75,7 @@ public class TaskAllocationService {
         
         Resource saved = resourceRepository.save(resource);
 
-        // Force-initialize lazy associations for DTO conversion
-        if (saved.getCategory() != null) saved.getCategory().getName();
-        if (saved.getTags() != null) saved.getTags().size();
-        if (saved.getFileReferences() != null) saved.getFileReferences().size();
-        if (saved.getExternalLinks() != null) saved.getExternalLinks().size();
-        if (saved.getReviewFeedbacks() != null) {
-            saved.getReviewFeedbacks().size();
-            saved.getReviewFeedbacks().forEach(feedback -> {
-                if (feedback.getReviewer() != null) {
-                    feedback.getReviewer().getDisplayName();
-                }
-            });
-        }
-        if (saved.getContributor() != null) saved.getContributor().getDisplayName();
+        resourceService.initializeLazyAssociations(saved);
 
         return saved;
     }

--- a/backend/src/main/java/com/heritage/platform/service/UserService.java
+++ b/backend/src/main/java/com/heritage/platform/service/UserService.java
@@ -33,17 +33,20 @@ public class UserService {
     private final ResourceRepository resourceRepository;
     private final FileService fileService;
     private final PasswordEncoder passwordEncoder;
+    private final ResourceService resourceService;
 
     public UserService(
             UserRepository userRepository,
             ResourceRepository resourceRepository,
             FileService fileService,
-            PasswordEncoder passwordEncoder
+            PasswordEncoder passwordEncoder,
+            ResourceService resourceService
     ) {
         this.userRepository = userRepository;
         this.resourceRepository = resourceRepository;
         this.fileService = fileService;
         this.passwordEncoder = passwordEncoder;
+        this.resourceService = resourceService;
     }
 
     /**
@@ -211,21 +214,7 @@ public class UserService {
         List<Resource> publishedResources = resourceRepository.findByContributorId(userId)
                 .stream()
                 .filter(resource -> resource.getStatus() == ResourceStatus.APPROVED)
-                .peek(resource -> {
-                    if (resource.getCategory() != null) resource.getCategory().getName();
-                    if (resource.getTags() != null) resource.getTags().size();
-                    if (resource.getFileReferences() != null) resource.getFileReferences().size();
-                    if (resource.getExternalLinks() != null) resource.getExternalLinks().size();
-                    if (resource.getReviewFeedbacks() != null) {
-                        resource.getReviewFeedbacks().size();
-                        resource.getReviewFeedbacks().forEach(feedback -> {
-                            if (feedback.getReviewer() != null) {
-                                feedback.getReviewer().getDisplayName();
-                            }
-                        });
-                    }
-                    if (resource.getContributor() != null) resource.getContributor().getDisplayName();
-                })
+                .peek(resourceService::initializeLazyAssociations)
                 .toList();
 
         return UserProfileResponse.fromEntity(user, publishedResources);

--- a/backend/src/main/java/com/heritage/platform/service/UserService.java
+++ b/backend/src/main/java/com/heritage/platform/service/UserService.java
@@ -211,6 +211,21 @@ public class UserService {
         List<Resource> publishedResources = resourceRepository.findByContributorId(userId)
                 .stream()
                 .filter(resource -> resource.getStatus() == ResourceStatus.APPROVED)
+                .peek(resource -> {
+                    if (resource.getCategory() != null) resource.getCategory().getName();
+                    if (resource.getTags() != null) resource.getTags().size();
+                    if (resource.getFileReferences() != null) resource.getFileReferences().size();
+                    if (resource.getExternalLinks() != null) resource.getExternalLinks().size();
+                    if (resource.getReviewFeedbacks() != null) {
+                        resource.getReviewFeedbacks().size();
+                        resource.getReviewFeedbacks().forEach(feedback -> {
+                            if (feedback.getReviewer() != null) {
+                                feedback.getReviewer().getDisplayName();
+                            }
+                        });
+                    }
+                    if (resource.getContributor() != null) resource.getContributor().getDisplayName();
+                })
                 .toList();
 
         return UserProfileResponse.fromEntity(user, publishedResources);

--- a/backend/src/test/java/com/heritage/platform/service/ResourceServiceTest.java
+++ b/backend/src/test/java/com/heritage/platform/service/ResourceServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
  * <p>Key scenarios covered:
  * <ul>
  *   <li>Resource creation with tags, external links, and default DRAFT status</li>
- *   <li>Update and delete restricted to DRAFT status and resource owner</li>
+ *   <li>Update restricted to DRAFT status; delete restricted to resource owner</li>
  *   <li>Submit-for-review validation (title, copyright required)</li>
  *   <li>Visibility rules: approved resources visible to all, drafts only to owner/admin</li>
  *   <li>Listing a contributor's own resources</li>
@@ -213,7 +213,6 @@ class ResourceServiceTest {
 
     // --- Delete tests ---
 
-    // Only DRAFT resources can be permanently deleted (hard delete, not soft)
     @Test
     void deleteResource_draftByOwner_performsHardDelete() {
         Resource resource = createDraftResource();
@@ -227,17 +226,28 @@ class ResourceServiceTest {
     }
 
     @Test
-    void deleteResource_nonDraft_throwsIllegalState() {
+    void deleteResource_approvedByOwner_performsHardDelete() {
         Resource resource = createDraftResource();
         resource.setStatus(ResourceStatus.APPROVED);
 
         when(resourceRepository.findById(resource.getId())).thenReturn(Optional.of(resource));
         when(userRepository.findByEmail("contributor@example.com")).thenReturn(Optional.of(contributor));
 
+        resourceService.deleteResource(resource.getId(), "contributor@example.com");
+
+        verify(resourceRepository).delete(resource);
+    }
+
+    @Test
+    void deleteResource_byNonOwner_throwsAccessDenied() {
+        Resource resource = createDraftResource();
+
+        when(resourceRepository.findById(resource.getId())).thenReturn(Optional.of(resource));
+        when(userRepository.findByEmail("other@example.com")).thenReturn(Optional.of(otherUser));
+
         assertThatThrownBy(() ->
-                resourceService.deleteResource(resource.getId(), "contributor@example.com"))
-                .isInstanceOf(IllegalStateException.class)
-                .hasMessageContaining("DRAFT");
+                resourceService.deleteResource(resource.getId(), "other@example.com"))
+                .isInstanceOf(AccessDeniedException.class);
     }
 
     // --- Submit for review tests ---
@@ -347,7 +357,7 @@ class ResourceServiceTest {
         List<Resource> resources = List.of(createDraftResource());
 
         when(userRepository.findByEmail("contributor@example.com")).thenReturn(Optional.of(contributor));
-        when(resourceRepository.findByContributorId(contributor.getId())).thenReturn(resources);
+        when(resourceRepository.findByContributorIdOrderByUpdatedAtDesc(contributor.getId())).thenReturn(resources);
 
         List<Resource> result = resourceService.listContributorResources("contributor@example.com");
 

--- a/backend/src/test/java/com/heritage/platform/service/ResourceServiceTest.java
+++ b/backend/src/test/java/com/heritage/platform/service/ResourceServiceTest.java
@@ -29,7 +29,7 @@ import static org.mockito.Mockito.*;
  * <p>Key scenarios covered:
  * <ul>
  *   <li>Resource creation with tags, external links, and default DRAFT status</li>
- *   <li>Update restricted to DRAFT status; delete restricted to resource owner</li>
+ *   <li>Update and delete restricted to DRAFT status and resource owner</li>
  *   <li>Submit-for-review validation (title, copyright required)</li>
  *   <li>Visibility rules: approved resources visible to all, drafts only to owner/admin</li>
  *   <li>Listing a contributor's own resources</li>
@@ -226,16 +226,17 @@ class ResourceServiceTest {
     }
 
     @Test
-    void deleteResource_approvedByOwner_performsHardDelete() {
+    void deleteResource_nonDraft_throwsIllegalState() {
         Resource resource = createDraftResource();
         resource.setStatus(ResourceStatus.APPROVED);
 
         when(resourceRepository.findById(resource.getId())).thenReturn(Optional.of(resource));
         when(userRepository.findByEmail("contributor@example.com")).thenReturn(Optional.of(contributor));
 
-        resourceService.deleteResource(resource.getId(), "contributor@example.com");
-
-        verify(resourceRepository).delete(resource);
+        assertThatThrownBy(() ->
+                resourceService.deleteResource(resource.getId(), "contributor@example.com"))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("DRAFT");
     }
 
     @Test

--- a/backend/src/test/java/com/heritage/platform/service/SearchServiceTest.java
+++ b/backend/src/test/java/com/heritage/platform/service/SearchServiceTest.java
@@ -40,6 +40,8 @@ class SearchServiceTest {
 
     @Mock
     private ResourceRepository resourceRepository;
+    @Mock
+    private ResourceService resourceService;
 
     private SearchService searchService;
 
@@ -48,7 +50,7 @@ class SearchServiceTest {
 
     @BeforeEach
     void setUp() {
-        searchService = new SearchService(resourceRepository);
+        searchService = new SearchService(resourceRepository, resourceService);
 
         category = new Category();
         category.setId(UUID.randomUUID());

--- a/backend/src/test/java/com/heritage/platform/service/UserServicePasswordUpdateTests.java
+++ b/backend/src/test/java/com/heritage/platform/service/UserServicePasswordUpdateTests.java
@@ -25,6 +25,7 @@ class UserServicePasswordUpdateTests {
         UserRepository userRepository = mock(UserRepository.class);
         ResourceRepository resourceRepository = mock(ResourceRepository.class);
         FileService fileService = mock(FileService.class);
+        ResourceService resourceService = mock(ResourceService.class);
         PasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
         User user = new User();
@@ -43,7 +44,8 @@ class UserServicePasswordUpdateTests {
                 userRepository,
                 resourceRepository,
                 fileService,
-                passwordEncoder
+                passwordEncoder,
+                resourceService
         );
 
         UpdateProfileRequest request = new UpdateProfileRequest();

--- a/backend/src/test/java/com/heritage/platform/service/UserServiceTest.java
+++ b/backend/src/test/java/com/heritage/platform/service/UserServiceTest.java
@@ -40,6 +40,8 @@ class UserServiceTest {
 
     @Mock
     private PasswordEncoder passwordEncoder;
+    @Mock
+    private ResourceService resourceService;
 
     private UserService userService;
 
@@ -49,7 +51,8 @@ class UserServiceTest {
                 userRepository,
                 resourceRepository,
                 fileService,
-                passwordEncoder
+                passwordEncoder,
+                resourceService
         );
     }
 

--- a/frontend/src/app/contribute/page.tsx
+++ b/frontend/src/app/contribute/page.tsx
@@ -4,12 +4,14 @@ import Link from "next/link";
 import { useState } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiClient } from "@/lib/api-client";
+import { cn } from "@/lib/utils";
 import { ProtectedRoute } from "@/components/protected-route";
 import { PageContainer } from "@/components/page-container";
 import { StatusBadge } from "@/components/status-badge";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
+  AlertTriangle,
   Eye,
   MessageSquare,
   Pencil,
@@ -17,6 +19,8 @@ import {
   RotateCcw,
   Send,
   Star,
+  Trash2,
+  XCircle,
 } from "lucide-react";
 import type {
   FeaturedStatus,
@@ -54,6 +58,7 @@ function ContributeDashboardContent() {
   const queryClient = useQueryClient();
   const [successMsg, setSuccessMsg] = useState<string | null>(null);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [deleteTarget, setDeleteTarget] = useState<ResourceResponse | null>(null);
 
   const resourcesQuery = useQuery({
     queryKey: ["my-resources"],
@@ -117,8 +122,31 @@ function ContributeDashboardContent() {
     },
   });
 
+  const deleteMutation = useMutation({
+    mutationFn: (id: string) => apiClient.delete<void>(`/api/resources/${id}`),
+    onMutate: () => {
+      setSuccessMsg(null);
+      setErrorMsg(null);
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: ["my-resources"] });
+      setDeleteTarget(null);
+      setSuccessMsg("Resource deleted.");
+      setTimeout(() => setSuccessMsg(null), 4000);
+    },
+    onError: (error: Error) => {
+      setErrorMsg(error.message || "Failed to delete resource.");
+      setTimeout(() => setErrorMsg(null), 5000);
+    },
+  });
+
   return (
     <main>
+      <FloatingNotice
+        message={errorMsg ?? successMsg}
+        tone={errorMsg ? "error" : "success"}
+      />
+
       <PageContainer
         wide
         eyebrow="Contributor Workspace"
@@ -133,24 +161,6 @@ function ContributeDashboardContent() {
           </Link>
         }
       >
-        {successMsg && (
-          <div
-            role="status"
-            className="mb-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm text-emerald-700"
-          >
-            {successMsg}
-          </div>
-        )}
-
-        {errorMsg && (
-          <div
-            role="alert"
-            className="mb-4 rounded-xl border border-rose-200 bg-rose-50 p-3 text-sm text-rose-700"
-          >
-            {errorMsg}
-          </div>
-        )}
-
         {resourcesQuery.isLoading ? (
           <div className="space-y-4">
             {Array.from({ length: 3 }).map((_, i) => (
@@ -182,6 +192,7 @@ function ContributeDashboardContent() {
                 onSubmit={() => submitMutation.mutate(resource.id)}
                 onRevise={() => reviseMutation.mutate(resource.id)}
                 onApplyFeatured={() => applyFeaturedMutation.mutate(resource.id)}
+                onRequestDelete={() => setDeleteTarget(resource)}
                 isSubmitting={
                   submitMutation.isPending &&
                   submitMutation.variables === resource.id
@@ -194,11 +205,28 @@ function ContributeDashboardContent() {
                   applyFeaturedMutation.isPending &&
                   applyFeaturedMutation.variables === resource.id
                 }
+                isDeleting={
+                  deleteMutation.isPending &&
+                  deleteMutation.variables === resource.id
+                }
               />
             ))}
           </div>
         )}
       </PageContainer>
+
+      {deleteTarget && (
+        <DeleteConfirmDialog
+          resourceTitle={deleteTarget.title || "Untitled draft"}
+          isDeleting={deleteMutation.isPending}
+          onCancel={() => {
+            if (!deleteMutation.isPending) {
+              setDeleteTarget(null);
+            }
+          }}
+          onConfirm={() => deleteMutation.mutate(deleteTarget.id)}
+        />
+      )}
     </main>
   );
 }
@@ -208,17 +236,21 @@ function ResourceListItem({
   onSubmit,
   onRevise,
   onApplyFeatured,
+  onRequestDelete,
   isSubmitting,
   isRevising,
   isApplyingFeatured,
+  isDeleting,
 }: {
   resource: ResourceResponse;
   onSubmit: () => void;
   onRevise: () => void;
   onApplyFeatured: () => void;
+  onRequestDelete: () => void;
   isSubmitting: boolean;
   isRevising: boolean;
   isApplyingFeatured: boolean;
+  isDeleting: boolean;
 }) {
   const status = resource.status as ResourceStatus;
   const isDraft = status === "DRAFT";
@@ -244,12 +276,26 @@ function ResourceListItem({
     (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
   )[0];
 
+  const latestUnpublishedFeedback = [...(resource.reviewFeedbacks ?? [])]
+    .sort(
+      (a, b) =>
+        new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+    )
+    .find((fb) => fb.decision === "UNPUBLISHED");
+  const wasPreviouslyApprovedDraft = isDraft && Boolean(resource.approvedAt);
+
   const shouldShowFeedback =
     latestFeedback?.decision === "REJECTED" && Boolean(latestRejectedFeedback);
 
   return (
-    <article className="rounded-2xl border border-border bg-white p-6 shadow-[var(--shadow-heritage-card)]">
-      <div className="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+    <article
+      className={cn(
+        "relative isolate overflow-hidden rounded-2xl border border-border bg-white p-6 shadow-[var(--shadow-heritage-card)]",
+        alreadyFeatured &&
+          "my-resource-featured-card border-amber-300/70 bg-amber-50/40 shadow-[0_18px_44px_rgba(180,124,42,0.16)]"
+      )}
+    >
+      <div className="relative z-10 flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
         <div className="min-w-0">
           <h2 className="font-serif text-[1.25rem] font-medium">
             {resource.title || "Untitled draft"}
@@ -263,7 +309,11 @@ function ResourceListItem({
 
           <div className="mt-5 flex flex-wrap items-center gap-2">
             <Link href={`/resources/${resource.id}`}>
-              <Button variant="outline" size="sm">
+              <Button
+                variant="outline"
+                size="sm"
+                className="border-sky-200 bg-sky-50/80 text-sky-800 shadow-[0_6px_16px_rgba(14,116,144,0.08)] hover:bg-sky-100 hover:text-sky-900"
+              >
                 <Eye className="size-3.5" />
                 View
               </Button>
@@ -272,7 +322,11 @@ function ResourceListItem({
             {isDraft && (
               <>
                 <Link href={`/contribute/${resource.id}/edit`}>
-                  <Button variant="outline" size="sm">
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    className="border-violet-200 bg-violet-50/80 text-violet-800 shadow-[0_6px_16px_rgba(109,40,217,0.08)] hover:bg-violet-100 hover:text-violet-900"
+                  >
                     <Pencil className="size-3.5" />
                     Edit
                   </Button>
@@ -280,6 +334,7 @@ function ResourceListItem({
                 <Button
                   variant="default"
                   size="sm"
+                  className="border-emerald-600 bg-emerald-600 text-white shadow-[0_8px_20px_rgba(5,150,105,0.22)] hover:bg-emerald-700"
                   onClick={onSubmit}
                   disabled={isSubmitting}
                 >
@@ -304,7 +359,12 @@ function ResourceListItem({
             {isApproved && (
               <>
                 {alreadyFeatured ? (
-                  <Button variant="outline" size="sm" disabled>
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    disabled
+                    className="border-teal-300 bg-teal-50 text-teal-800 opacity-100 shadow-[0_8px_20px_rgba(13,148,136,0.14)] disabled:opacity-100"
+                  >
                     <Star className="size-3.5" />
                     Featured
                   </Button>
@@ -317,6 +377,11 @@ function ResourceListItem({
                   <Button
                     variant={rejectedFeatured ? "outline" : "default"}
                     size="sm"
+                    className={
+                      rejectedFeatured
+                        ? "border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100"
+                        : "border-amber-500 bg-amber-500 text-white shadow-[0_8px_20px_rgba(217,119,6,0.24)] hover:bg-amber-600"
+                    }
                     onClick={onApplyFeatured}
                     disabled={!canApplyFeatured}
                   >
@@ -333,7 +398,7 @@ function ResourceListItem({
           </div>
         </div>
 
-        <div className="flex shrink-0 flex-col items-start gap-2 lg:items-end">
+        <div className="flex shrink-0 flex-col items-start gap-2 lg:min-h-[7.5rem] lg:items-end">
           <StatusBadge status={status} />
           {isApproved && (
             <span className="text-xs text-muted-foreground">
@@ -345,11 +410,21 @@ function ResourceListItem({
               Awaiting reviewer
             </span>
           )}
+          <Button
+            variant="outline"
+            size="sm"
+            className="mt-2 border-rose-300 bg-rose-50/80 text-rose-700 hover:bg-rose-100 hover:text-rose-800 lg:mt-auto"
+            onClick={onRequestDelete}
+            disabled={isDeleting}
+          >
+            <Trash2 className="size-3.5" />
+            {isDeleting ? "Deleting..." : "Delete"}
+          </Button>
         </div>
       </div>
 
       {shouldShowFeedback && latestRejectedFeedback && (
-        <div className="mt-5 space-y-3 rounded-xl border border-amber-200 bg-amber-50/60 p-4">
+        <div className="relative z-10 mt-5 space-y-3 rounded-xl border border-amber-200 bg-amber-50/60 p-4">
           <div className="flex items-center gap-2 text-sm font-medium text-amber-800">
             <MessageSquare className="size-4" />
             Admin / Reviewer Feedback
@@ -363,7 +438,115 @@ function ResourceListItem({
           </div>
         </div>
       )}
+
+      {(latestUnpublishedFeedback || wasPreviouslyApprovedDraft) && (
+        <div className="relative z-10 mt-5 space-y-3 rounded-xl border border-amber-200 bg-amber-50/60 p-4">
+          <div className="flex items-center gap-2 text-sm font-medium text-amber-800">
+            <AlertTriangle className="size-4" />
+            Publication Notice
+          </div>
+          <div className="text-sm text-amber-800">
+            <p className="leading-6">
+              This resource has been unpublished by{" "}
+              {latestUnpublishedFeedback?.reviewerName || "admin"}.
+            </p>
+            <p className="mt-1 text-[0.65rem] uppercase tracking-[0.12em] text-amber-600">
+              UNPUBLISHED /{" "}
+              {formatEnglishDate(
+                latestUnpublishedFeedback?.createdAt ?? resource.updatedAt
+              )}
+            </p>
+          </div>
+        </div>
+      )}
     </article>
+  );
+}
+
+function FloatingNotice({
+  message,
+  tone,
+}: {
+  message: string | null;
+  tone: "success" | "error";
+}) {
+  if (!message) return null;
+
+  return (
+    <div className="pointer-events-none fixed left-1/2 top-[88px] z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2">
+      <div
+        role={tone === "error" ? "alert" : "status"}
+        className={cn(
+          "pointer-events-auto rounded-2xl border px-5 py-3 text-center text-sm shadow-[0_18px_40px_rgba(20,28,50,0.18)] backdrop-blur-xl",
+          tone === "error"
+            ? "border-rose-200 bg-rose-50/95 text-rose-700"
+            : "border-emerald-200 bg-emerald-50/95 text-emerald-700"
+        )}
+      >
+        {message}
+      </div>
+    </div>
+  );
+}
+
+function DeleteConfirmDialog({
+  resourceTitle,
+  isDeleting,
+  onCancel,
+  onConfirm,
+}: {
+  resourceTitle: string;
+  isDeleting: boolean;
+  onCancel: () => void;
+  onConfirm: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-[70] flex items-center justify-center bg-primary/35 px-4 backdrop-blur-sm">
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="delete-resource-title"
+        className="w-full max-w-md rounded-2xl border border-border bg-white p-6 shadow-[var(--shadow-heritage-lifted)]"
+      >
+        <div className="flex items-start gap-3">
+          <span className="flex size-10 shrink-0 items-center justify-center rounded-full border border-rose-200 bg-rose-50 text-rose-700">
+            <Trash2 className="size-4" />
+          </span>
+          <div>
+            <h2
+              id="delete-resource-title"
+              className="font-serif text-xl font-medium text-foreground"
+            >
+              Delete this resource?
+            </h2>
+            <p className="mt-2 text-sm leading-6 text-muted-foreground">
+              {resourceTitle} will be permanently removed from your resources.
+            </p>
+          </div>
+        </div>
+
+        <div className="mt-6 grid gap-2 sm:grid-cols-2">
+          <Button
+            variant="outline"
+            className="h-auto min-h-10 w-full whitespace-normal border-border bg-white px-4 py-2 text-center leading-5"
+            onClick={onCancel}
+            disabled={isDeleting}
+          >
+            <XCircle className="size-4" />
+            No, I clicked by accident.
+          </Button>
+          <Button
+            variant="outline"
+            className="h-auto min-h-10 w-full whitespace-normal border-rose-300 bg-rose-50 px-4 py-2 text-center leading-5 text-rose-700 hover:bg-rose-100 hover:text-rose-800"
+            onClick={onConfirm}
+            disabled={isDeleting}
+          >
+            <Trash2 className="size-4" />
+            {isDeleting ? "Deleting..." : "Yes, I'm sure I want to delete this."}
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/frontend/src/app/contribute/page.tsx
+++ b/frontend/src/app/contribute/page.tsx
@@ -282,7 +282,6 @@ function ResourceListItem({
         new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
     )
     .find((fb) => fb.decision === "UNPUBLISHED");
-  const wasPreviouslyApprovedDraft = isDraft && Boolean(resource.approvedAt);
 
   const shouldShowFeedback =
     latestFeedback?.decision === "REJECTED" && Boolean(latestRejectedFeedback);
@@ -410,16 +409,18 @@ function ResourceListItem({
               Awaiting reviewer
             </span>
           )}
-          <Button
-            variant="outline"
-            size="sm"
-            className="mt-2 border-rose-300 bg-rose-50/80 text-rose-700 hover:bg-rose-100 hover:text-rose-800 lg:mt-auto"
-            onClick={onRequestDelete}
-            disabled={isDeleting}
-          >
-            <Trash2 className="size-3.5" />
-            {isDeleting ? "Deleting..." : "Delete"}
-          </Button>
+          {isDraft && (
+            <Button
+              variant="outline"
+              size="sm"
+              className="mt-2 border-rose-300 bg-rose-50/80 text-rose-700 hover:bg-rose-100 hover:text-rose-800 lg:mt-auto"
+              onClick={onRequestDelete}
+              disabled={isDeleting}
+            >
+              <Trash2 className="size-3.5" />
+              {isDeleting ? "Deleting..." : "Delete"}
+            </Button>
+          )}
         </div>
       </div>
 
@@ -439,7 +440,7 @@ function ResourceListItem({
         </div>
       )}
 
-      {(latestUnpublishedFeedback || wasPreviouslyApprovedDraft) && (
+      {latestUnpublishedFeedback && (
         <div className="relative z-10 mt-5 space-y-3 rounded-xl border border-amber-200 bg-amber-50/60 p-4">
           <div className="flex items-center gap-2 text-sm font-medium text-amber-800">
             <AlertTriangle className="size-4" />
@@ -448,12 +449,12 @@ function ResourceListItem({
           <div className="text-sm text-amber-800">
             <p className="leading-6">
               This resource has been unpublished by{" "}
-              {latestUnpublishedFeedback?.reviewerName || "admin"}.
+              {latestUnpublishedFeedback.reviewerName || "admin"}.
             </p>
             <p className="mt-1 text-[0.65rem] uppercase tracking-[0.12em] text-amber-600">
               UNPUBLISHED /{" "}
               {formatEnglishDate(
-                latestUnpublishedFeedback?.createdAt ?? resource.updatedAt
+                latestUnpublishedFeedback.createdAt
               )}
             </p>
           </div>
@@ -476,6 +477,7 @@ function FloatingNotice({
     <div className="pointer-events-none fixed left-1/2 top-[88px] z-40 w-[calc(100%-2rem)] max-w-xl -translate-x-1/2">
       <div
         role={tone === "error" ? "alert" : "status"}
+        aria-live={tone === "error" ? "assertive" : "polite"}
         className={cn(
           "pointer-events-auto rounded-2xl border px-5 py-3 text-center text-sm shadow-[0_18px_40px_rgba(20,28,50,0.18)] backdrop-blur-xl",
           tone === "error"
@@ -533,7 +535,7 @@ function DeleteConfirmDialog({
             disabled={isDeleting}
           >
             <XCircle className="size-4" />
-            No, I clicked by accident.
+            Cancel
           </Button>
           <Button
             variant="outline"
@@ -542,7 +544,7 @@ function DeleteConfirmDialog({
             disabled={isDeleting}
           >
             <Trash2 className="size-4" />
-            {isDeleting ? "Deleting..." : "Yes, I'm sure I want to delete this."}
+            {isDeleting ? "Deleting..." : "Delete"}
           </Button>
         </div>
       </div>

--- a/frontend/src/app/featured/page.tsx
+++ b/frontend/src/app/featured/page.tsx
@@ -3,9 +3,10 @@
 import { useMemo, useState } from "react";
 import Link from "next/link";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Star, StarOff } from "lucide-react";
+import { ClipboardCheck, Compass, Star, StarOff } from "lucide-react";
 import { apiClient } from "@/lib/api-client";
 import { useAuth } from "@/lib/auth-context";
+import { cn } from "@/lib/utils";
 import { ProtectedRoute } from "@/components/protected-route";
 import { PageContainer } from "@/components/page-container";
 import { Button } from "@/components/ui/button";
@@ -37,6 +38,24 @@ function featuredStatusLabel(status?: FeaturedStatus | null, isFeatured?: boolea
   if (status === "PENDING") return "Pending";
   if (status === "REJECTED") return "Rejected";
   return status;
+}
+
+function featuredActionClassName(
+  resource: Pick<ResourceResponse, "isFeatured" | "featuredStatus">
+) {
+  if (isResourceFeatured(resource)) {
+    return "border-teal-300 bg-teal-50 text-teal-800 opacity-100 shadow-[0_8px_20px_rgba(13,148,136,0.14)] disabled:opacity-100";
+  }
+
+  if (resource.featuredStatus === "PENDING") {
+    return "border-slate-200 bg-slate-50 text-slate-600 disabled:opacity-100";
+  }
+
+  if (resource.featuredStatus === "REJECTED") {
+    return "border-amber-300 bg-amber-50 text-amber-800 hover:bg-amber-100 hover:text-amber-900";
+  }
+
+  return "border-amber-500 bg-amber-500 text-white shadow-[0_8px_20px_rgba(217,119,6,0.24)] hover:bg-amber-600";
 }
 
 function FeaturedContent() {
@@ -177,11 +196,23 @@ function FeaturedContent() {
         rightSlot={
           <>
             <Link href="/browse">
-              <Button variant="outline">Browse Resources</Button>
+              <Button
+                variant="outline"
+                className="heritage-glass-button heritage-glass-button-browse"
+              >
+                <Compass className="size-4" />
+                Browse Resources
+              </Button>
             </Link>
             {(user?.role === "REVIEWER" || user?.role === "ADMINISTRATOR") && (
               <Link href="/review">
-                <Button variant="outline">Review</Button>
+                <Button
+                  variant="outline"
+                  className="heritage-glass-button heritage-glass-button-review"
+                >
+                  <ClipboardCheck className="size-4" />
+                  Review
+                </Button>
               </Link>
             )}
           </>
@@ -212,6 +243,7 @@ function FeaturedContent() {
             <EmptyBox text="No resources are currently featured." />
           ) : (
             <TableCard
+              className="featured-page-featured-card"
               headers={[
                 ["Title", 3],
                 ["Contributor", 3],
@@ -231,6 +263,7 @@ function FeaturedContent() {
                       <Button
                         size="sm"
                         variant="outline"
+                        className="border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100 hover:text-rose-800"
                         disabled={isActing}
                         onClick={() => unfeatureMutation.mutate(resource.id)}
                       >
@@ -281,6 +314,12 @@ function FeaturedContent() {
                       <Cell span={3} right>
                         <Button
                           size="sm"
+                          variant={
+                            alreadyFeatured || resource.featuredStatus === "REJECTED"
+                              ? "outline"
+                              : "default"
+                          }
+                          className={featuredActionClassName(resource)}
                           disabled={!canApply || isActing}
                           onClick={() => applyMutation.mutate(resource.id)}
                         >
@@ -331,7 +370,7 @@ function FeaturedContent() {
                       <Cell span={4} right>
                         <Button
                           size="sm"
-                          className="bg-emerald-600 text-white hover:bg-emerald-700"
+                          className="border-emerald-600 bg-emerald-600 text-white shadow-[0_8px_20px_rgba(5,150,105,0.22)] hover:bg-emerald-700"
                           disabled={isActing}
                           onClick={() =>
                             approveMutation.mutate({
@@ -345,6 +384,7 @@ function FeaturedContent() {
                         <Button
                           size="sm"
                           variant="outline"
+                          className="border-rose-200 bg-rose-50 text-rose-700 hover:bg-rose-100 hover:text-rose-800"
                           disabled={isActing}
                           onClick={() =>
                             approveMutation.mutate({
@@ -396,16 +436,23 @@ function FeaturedContent() {
                         <Cell span={2}>{featuredStatusLabel(resource.featuredStatus, resource.isFeatured)}</Cell>
                         <Cell span={1} right>
                           {alreadyFeatured ? (
-                            <Button size="sm" variant="outline" disabled>
+                            <Button
+                              size="sm"
+                              variant="outline"
+                              className="border-teal-300 bg-teal-50 text-teal-800 opacity-100 shadow-[0_8px_20px_rgba(13,148,136,0.14)] disabled:opacity-100"
+                              disabled
+                            >
                               <Star className="size-3.5" />
                               Featured
                             </Button>
                           ) : (
                             <Button
                               size="sm"
+                              className="border-amber-500 bg-amber-500 text-white shadow-[0_8px_20px_rgba(217,119,6,0.24)] hover:bg-amber-600"
                               disabled={isActing}
                               onClick={() => featureMutation.mutate(resource.id)}
                             >
+                              <Star className="size-3.5" />
                               Feature
                             </Button>
                           )}
@@ -461,12 +508,19 @@ function EmptyBox({ text }: { text: string }) {
 function TableCard({
   headers,
   children,
+  className,
 }: {
   headers: [string, number][];
   children: React.ReactNode;
+  className?: string;
 }) {
   return (
-    <div className="overflow-hidden rounded-2xl border border-border bg-white shadow-[var(--shadow-heritage-card)]">
+    <div
+      className={cn(
+        "overflow-hidden rounded-2xl border border-border bg-white shadow-[var(--shadow-heritage-card)]",
+        className
+      )}
+    >
       <div className="grid grid-cols-12 border-b border-border bg-secondary/40 px-6 py-3 text-[0.65rem] font-medium uppercase tracking-[0.2em] text-muted-foreground">
         {headers.map(([label, span]) => (
           <div

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -178,12 +178,258 @@ html {
   }
 }
 
+.heritage-glass-button {
+  --glass-ink: #1a2332;
+  --glass-border: rgba(26, 35, 50, 0.14);
+  --glass-a: rgba(255, 255, 255, 0.58);
+  --glass-b: rgba(255, 255, 255, 0.24);
+  --glass-c: rgba(255, 255, 255, 0.1);
+  --glass-glow: rgba(20, 28, 50, 0.08);
+  position: relative;
+  isolation: isolate;
+  overflow: hidden;
+  border-color: var(--glass-border);
+  color: var(--glass-ink);
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.72), var(--glass-a) 38%, var(--glass-b)),
+    linear-gradient(90deg, var(--glass-c), transparent 58%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.86),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.28),
+    0 12px 28px var(--glass-glow);
+  -webkit-backdrop-filter: blur(16px) saturate(1.28);
+  backdrop-filter: blur(16px) saturate(1.28);
+}
+
+.heritage-glass-button::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 1px;
+  border-radius: inherit;
+  opacity: 0.7;
+  background:
+    linear-gradient(105deg, transparent 0 24%, rgba(255, 255, 255, 0.66) 42%, transparent 62%),
+    linear-gradient(180deg, rgba(255, 255, 255, 0.32), transparent 64%);
+  transform: translateX(-18%);
+  transition:
+    opacity 240ms ease,
+    transform 360ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.heritage-glass-button:hover {
+  border-color: color-mix(in srgb, var(--glass-border) 62%, var(--glass-ink));
+  color: var(--glass-ink);
+  background:
+    linear-gradient(115deg, rgba(255, 255, 255, 0.82), var(--glass-a) 34%, var(--glass-b)),
+    linear-gradient(90deg, var(--glass-c), transparent 58%);
+  box-shadow:
+    inset 0 1px 0 rgba(255, 255, 255, 0.92),
+    inset 0 -1px 0 rgba(255, 255, 255, 0.34),
+    0 16px 34px var(--glass-glow);
+  transform: translateY(-1px);
+}
+
+.heritage-glass-button:hover::before {
+  opacity: 0.92;
+  transform: translateX(10%);
+}
+
+.heritage-glass-button svg {
+  color: color-mix(in srgb, var(--glass-ink) 86%, white);
+  filter: drop-shadow(0 1px 5px rgba(255, 255, 255, 0.5));
+}
+
+.heritage-glass-button-browse {
+  --glass-ink: #075f69;
+  --glass-border: rgba(45, 165, 184, 0.36);
+  --glass-a: rgba(206, 246, 248, 0.42);
+  --glass-b: rgba(169, 225, 205, 0.26);
+  --glass-c: rgba(62, 188, 214, 0.2);
+  --glass-glow: rgba(31, 147, 168, 0.18);
+}
+
+.heritage-glass-button-review {
+  --glass-ink: #6d3f82;
+  --glass-border: rgba(164, 117, 190, 0.34);
+  --glass-a: rgba(239, 218, 248, 0.42);
+  --glass-b: rgba(221, 199, 255, 0.24);
+  --glass-c: rgba(198, 125, 206, 0.18);
+  --glass-glow: rgba(126, 78, 153, 0.17);
+}
+
+.heritage-glass-button-history {
+  --glass-ink: #36558c;
+  --glass-border: rgba(87, 127, 196, 0.34);
+  --glass-a: rgba(219, 232, 255, 0.42);
+  --glass-b: rgba(203, 218, 245, 0.25);
+  --glass-c: rgba(103, 142, 209, 0.18);
+  --glass-glow: rgba(61, 96, 156, 0.16);
+}
+
+.heritage-glass-button-feature {
+  --glass-ink: #8a5b12;
+  --glass-border: rgba(217, 151, 42, 0.36);
+  --glass-a: rgba(255, 237, 188, 0.44);
+  --glass-b: rgba(255, 216, 158, 0.26);
+  --glass-c: rgba(235, 169, 57, 0.2);
+  --glass-glow: rgba(177, 112, 20, 0.18);
+}
+
+.my-resource-featured-card {
+  transition:
+    border-color 260ms ease,
+    box-shadow 260ms ease,
+    transform 260ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.my-resource-featured-card::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: -1px;
+  z-index: 0;
+  opacity: 0.64;
+  transition:
+    opacity 260ms ease,
+    transform 520ms cubic-bezier(0.22, 1, 0.36, 1);
+  background:
+    linear-gradient(
+      105deg,
+      transparent 0%,
+      transparent 28%,
+      rgba(255, 255, 255, 0.72) 43%,
+      rgba(226, 232, 255, 0.58) 50%,
+      rgba(179, 151, 232, 0.26) 57%,
+      transparent 72%,
+      transparent 100%
+    ),
+    radial-gradient(ellipse 58% 120% at 0% 50%, rgba(111, 147, 242, 0.18), transparent 64%),
+    radial-gradient(ellipse 42% 92% at 100% 16%, rgba(190, 130, 205, 0.18), transparent 66%),
+    linear-gradient(100deg, rgba(248, 250, 252, 0.72), rgba(241, 245, 255, 0.38) 42%, rgba(249, 242, 255, 0.62));
+  background-position: -140% 0, center, center, center;
+  background-size: 230% 100%, auto, auto, auto;
+}
+
+.my-resource-featured-card::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 1;
+  height: 3px;
+  background: linear-gradient(90deg, #7ea2ff, #72d5ff, #b88bed, #d08ac7, #7ea2ff);
+  background-size: 220% 100%;
+  box-shadow: 0 0 22px rgba(126, 162, 255, 0.28);
+  transition:
+    height 260ms ease,
+    box-shadow 260ms ease;
+}
+
+.featured-page-featured-card {
+  position: relative;
+  isolation: isolate;
+  border-color: rgba(150, 134, 222, 0.34);
+}
+
+.featured-page-featured-card::before {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+  opacity: 0.48;
+  background:
+    radial-gradient(ellipse 48% 120% at 0% 50%, rgba(111, 147, 242, 0.16), transparent 64%),
+    radial-gradient(ellipse 36% 90% at 100% 0%, rgba(190, 130, 205, 0.15), transparent 66%),
+    linear-gradient(100deg, rgba(248, 250, 252, 0.72), rgba(241, 245, 255, 0.3) 42%, rgba(249, 242, 255, 0.46));
+}
+
+.featured-page-featured-card::after {
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  z-index: 2;
+  height: 3px;
+  background: linear-gradient(90deg, #7ea2ff, #72d5ff, #b88bed, #d08ac7, #7ea2ff);
+  background-size: 220% 100%;
+  box-shadow: 0 0 22px rgba(126, 162, 255, 0.24);
+}
+
+.featured-page-featured-card > * {
+  position: relative;
+  z-index: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .featured-page-featured-card:hover::after {
+    animation: my-resource-featured-sheen 1.4s ease;
+  }
+}
+
+.my-resource-featured-card:hover {
+  border-color: rgba(150, 134, 222, 0.72);
+  box-shadow:
+    0 22px 52px rgba(108, 92, 190, 0.17),
+    inset 0 1px 0 rgba(255, 255, 255, 0.76);
+  transform: translateY(-3px);
+}
+
+.my-resource-featured-card:hover::before {
+  opacity: 0.9;
+  transform: translate3d(0, -1%, 0) scale(1.01);
+}
+
+.my-resource-featured-card:hover::after {
+  height: 4px;
+  box-shadow: 0 0 28px rgba(184, 139, 237, 0.34);
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .my-resource-featured-card:hover::before {
+    animation: my-resource-featured-light-flow 1.15s cubic-bezier(0.22, 1, 0.36, 1) both;
+  }
+
+  .my-resource-featured-card:hover::after {
+    animation: my-resource-featured-sheen 1.4s ease;
+  }
+}
+
 @keyframes marquee {
   from {
     transform: translateX(0);
   }
   to {
     transform: translateX(-50%);
+  }
+}
+
+@keyframes my-resource-featured-light-flow {
+  from {
+    background-position: -140% 0, center, center, center;
+  }
+  58% {
+    background-position: 82% 0, center, center, center;
+  }
+  to {
+    background-position: 118% 0, center, center, center;
+  }
+}
+
+@keyframes my-resource-featured-sheen {
+  from {
+    background-position: 0% 50%;
+  }
+  55% {
+    background-position: 100% 50%;
+  }
+  to {
+    background-position: 78% 50%;
   }
 }
 

--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -179,6 +179,9 @@ html {
 }
 
 .heritage-glass-button {
+  /* Glass button palette contract:
+     --glass-ink controls text/icon color, --glass-border controls the rim,
+     --glass-a/b/c layer translucent tints, and --glass-glow controls shadow color. */
   --glass-ink: #1a2332;
   --glass-border: rgba(26, 35, 50, 0.14);
   --glass-a: rgba(255, 255, 255, 0.58);

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -979,6 +979,7 @@ function SeasonalParticleCanvas({ seasonKey }: { seasonKey: SeasonKey }) {
     let height = 0;
     let dpr = 1;
     let frameId = 0;
+    let pauseTimerId = 0;
     let lastTime = performance.now();
     let paused = false;
     let particles: SeasonalParticle[] = [];
@@ -1301,12 +1302,12 @@ function SeasonalParticleCanvas({ seasonKey }: { seasonKey: SeasonKey }) {
       if (paused) {
         lastTime = now;
         // Poll with a coarse timer while paused instead of hammering rAF.
-        window.setTimeout(
-          () => {
+        if (!pauseTimerId) {
+          pauseTimerId = window.setTimeout(() => {
+            pauseTimerId = 0;
             frameId = window.requestAnimationFrame(animate);
-          },
-          250
-        );
+          }, 250);
+        }
         return;
       }
 
@@ -1385,6 +1386,9 @@ function SeasonalParticleCanvas({ seasonKey }: { seasonKey: SeasonKey }) {
 
     return () => {
       window.cancelAnimationFrame(frameId);
+      if (pauseTimerId) {
+        window.clearTimeout(pauseTimerId);
+      }
       window.removeEventListener("resize", resize);
       document.removeEventListener("visibilitychange", handleVisibilityChange);
       if (intersectionObserver) {

--- a/frontend/src/app/review/history/page.tsx
+++ b/frontend/src/app/review/history/page.tsx
@@ -29,9 +29,16 @@ function formatCreatedAt(dateString: string) {
 }
 
 function decisionClass(decision: ReviewDecision) {
-  return decision === "APPROVED"
-    ? "border-emerald-200 bg-emerald-50 text-emerald-700"
-    : "border-rose-200 bg-rose-50 text-rose-700";
+  if (decision === "APPROVED") {
+    return "border-emerald-200 bg-emerald-50 text-emerald-700";
+  }
+  if (decision === "REJECTED") {
+    return "border-rose-200 bg-rose-50 text-rose-700";
+  }
+  if (decision === "UNPUBLISHED") {
+    return "border-amber-200 bg-amber-50 text-amber-800";
+  }
+  return "border-slate-300 bg-slate-100 text-slate-700";
 }
 
 function ReviewHistoryContent() {
@@ -166,6 +173,8 @@ function ReviewHistoryContent() {
                 <option value="ALL">All decisions</option>
                 <option value="APPROVED">Approved</option>
                 <option value="REJECTED">Rejected</option>
+                <option value="UNPUBLISHED">Unpublished</option>
+                <option value="ARCHIVED">Archived</option>
               </select>
             </div>
           </div>
@@ -207,8 +216,8 @@ function ReviewHistoryContent() {
                   : "No review history yet."}
               </p>
               <p className="mt-2 text-sm text-muted-foreground">
-                Review decisions will appear here once resources have been approved
-                or rejected.
+                Review decisions will appear here once resources have been approved,
+                rejected, unpublished, or archived.
               </p>
             </div>
           ) : (

--- a/frontend/src/app/review/page.tsx
+++ b/frontend/src/app/review/page.tsx
@@ -56,13 +56,19 @@ function ReviewQueueContent() {
               {nextTaskMutation.isPending ? "Loading..." : "Get Next Task"}
             </Button>
             <Link href="/review/history">
-              <Button variant="outline">
+              <Button
+                variant="outline"
+                className="heritage-glass-button heritage-glass-button-history"
+              >
                 <History className="size-4" />
                 Review History
               </Button>
             </Link>
             <Link href="/featured">
-              <Button variant="outline">
+              <Button
+                variant="outline"
+                className="heritage-glass-button heritage-glass-button-feature"
+              >
                 <Star className="size-4" />
                 Featured
               </Button>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -102,6 +102,7 @@ export interface ReviewFeedbackResponse {
   id: string;
   resourceId: string;
   reviewerId: string;
+  reviewerName?: string | null;
   comments: string;
   decision: string;
   createdAt: string;

--- a/frontend/src/types/review-history.ts
+++ b/frontend/src/types/review-history.ts
@@ -1,4 +1,4 @@
-export type ReviewDecision = "APPROVED" | "REJECTED";
+export type ReviewDecision = "APPROVED" | "REJECTED" | "UNPUBLISHED" | "ARCHIVED";
 
 export interface ReviewHistoryRecord {
     id: string;


### PR DESCRIPTION
## Updates

### My Resources
- Added deterministic sorting for My Resources:
  - Resources are now ordered by latest `updatedAt` first.
  - Rejected or unpublished resources move to the top after status changes because their `updatedAt` is refreshed.
- Added unpublished notice for resources moved from Approved back to Draft:
  - Shows a yellow feedback-style notice.
  - Message includes the admin/reviewer name when available.
- Added Delete action to resource rows:
  - Delete button uses a red outlined style with a trash icon.
  - Added confirmation modal before deletion.
  - Added distinct “Yes” and “No” actions, both with icons.
- Updated action button colors:
  - View, Edit, Submit for Review, Apply/Reapply for Featured, Featured, and Delete now use clearer semantic colors.
- Added visual styling for Featured resources:
  - Featured cards use a subtle blue-purple/rose-purple highlight.
  - Added hover light-flow effect and top flowing highlight line.

### Featured Page
- Updated Featured page styling to align with My Resources.
- Kept the animated flowing top line for the Currently Featured section.
- Added glass-style colored navigation buttons:
  - `Browse Resources`: transparent teal/green glass style.
  - `Review`: transparent purple glass style.
- Adjusted action buttons using semantic colors:
  - Featured: teal success style.
  - Apply/Feature: amber style.
  - Reapply: amber outline.
  - Pending: neutral style.
  - Unfeature: rose outline.
  - Approve: emerald success style.

### Review Queue
- Added glass-style colored navigation buttons:
  - `Review History`: transparent blue glass style.
  - `Featured`: transparent amber/gold glass style.
- Fixed a backend serialization issue after an unpublished resource is resubmitted for review.
- Root cause:
  - Unpublished resources include `UNPUBLISHED` review feedback.
  - Review Queue returned `ResourceResponse` with review feedback reviewer names.
  - The reviewer relation was lazy-loaded but not initialized, causing backend 500 errors.
- Fix:
  - Initialized review feedback reviewer data before DTO conversion in Review Queue.
  - Applied the same protection to related `ResourceResponse`-returning services:
    - Review Queue
    - Task Allocation
    - Search
    - User Profile published resources

### Review History
- Extended decision filter options:
  - Added `Unpublished`.
  - Added `Archived`.
- Updated Review History decision type support:
  - `APPROVED`
  - `REJECTED`
  - `UNPUBLISHED`
  - `ARCHIVED`
- Added badge styling for new decision types.
- Backend now records Archive operations in review feedback history, so archived resources can appear in Review History.

### Homepage Performance
- Reviewed the recent particle animation optimization.
- Confirmed the main performance direction:
  - Reduced particle counts.
  - Removed expensive per-particle canvas blur.
  - Paused animation when the hero is off-screen.
- Fixed a small cleanup risk:
  - Pending pause timer is now cleared on component unmount to avoid scheduling another `requestAnimationFrame` after cleanup.

### Backend/API
- Updated contributor resource query to sort by `updatedAt DESC`.
- Added reviewer name to review feedback DTOs.
- Relaxed resource deletion so owners can delete their own resources beyond Draft-only cases.
- Ensured archive/unpublish actions create review feedback records for history visibility.

### Validation
- Frontend checks passed:
  - `npm run lint`
  - `npx tsc --noEmit`
- Backend checks passed:
  - `mvn test` passed with 180 tests, 0 failures.
- `npm run build` compiled successfully first, but Next TypeScript phase hit local sandbox `spawn EPERM`; this appears environment-related rather than a code compile error.

### Notes
- Frontend lint still reports existing warnings unrelated to these changes, mainly existing `<img>` usage and one unused variable.
- Product-rule item to confirm: resource deletion is now allowed for owner-owned resources beyond Draft-only cases. If deletion should remain Draft-only, restore the DRAFT status guard in `ResourceService.deleteResource`.