### PR TITLE
Fix public profile resource images

### DIFF
--- a/backend/src/main/java/com/heritage/platform/controller/UserController.java
+++ b/backend/src/main/java/com/heritage/platform/controller/UserController.java
@@ -114,7 +114,11 @@ public class UserController {
     }
 
     @GetMapping("/{userId}/profile")
-    public ResponseEntity<UserProfileResponse> getUserProfile(@PathVariable UUID userId) {
-        return ResponseEntity.ok(userService.getUserProfile(userId));
+    public ResponseEntity<UserProfileResponse> getUserProfile(
+            @PathVariable UUID userId,
+            Principal principal
+    ) {
+        String requesterEmail = principal != null ? principal.getName() : null;
+        return ResponseEntity.ok(userService.getUserProfile(userId, requesterEmail));
     }
 }

--- a/backend/src/main/java/com/heritage/platform/dto/UserProfileResponse.java
+++ b/backend/src/main/java/com/heritage/platform/dto/UserProfileResponse.java
@@ -5,6 +5,7 @@ import com.heritage.platform.model.User;
 
 import java.util.List;
 import java.util.UUID;
+import java.util.function.Function;
 
 public class UserProfileResponse {
 
@@ -22,23 +23,41 @@ public class UserProfileResponse {
     private List<ResourceResponse> publishedResources;
 
     public static UserProfileResponse fromEntity(User user, List<Resource> publishedResources) {
+        return fromEntity(user, publishedResources, null, true);
+    }
+
+    public static UserProfileResponse fromEntity(User user,
+                                                 List<Resource> publishedResources,
+                                                 Function<String, String> downloadUrlGenerator) {
+        return fromEntity(user, publishedResources, downloadUrlGenerator, true);
+    }
+
+    public static UserProfileResponse fromEntity(User user,
+                                                 List<Resource> publishedResources,
+                                                 Function<String, String> downloadUrlGenerator,
+                                                 boolean includePrivateProfileFields) {
         UserProfileResponse response = new UserProfileResponse();
+        boolean profileVisible = user.isProfilePublic() || includePrivateProfileFields;
 
         response.id = user.getId();
-        response.email = user.getEmail();
+        response.email = profileVisible && (user.isShowEmail() || includePrivateProfileFields)
+                ? user.getEmail()
+                : null;
         response.displayName = user.getDisplayName();
         response.role = user.getRole().name();
-        response.contributorRequested = user.isContributorRequested();
+        response.contributorRequested = includePrivateProfileFields && user.isContributorRequested();
 
         response.avatarUrl = user.getAvatarUrl();
         response.profilePublic = user.isProfilePublic();
-        response.showEmail = user.isShowEmail();
-        response.bio = user.getBio();
+        response.showEmail = profileVisible && (user.isShowEmail() || includePrivateProfileFields);
+        response.bio = profileVisible ? user.getBio() : null;
 
-        response.publishedResources = publishedResources == null
+        response.publishedResources = !profileVisible || publishedResources == null
                 ? List.of()
                 : publishedResources.stream()
-                        .map(ResourceResponse::fromEntity)
+                        .map(resource -> downloadUrlGenerator == null
+                                ? ResourceResponse.fromEntity(resource)
+                                : ResourceResponse.fromEntityWithFileUrls(resource, downloadUrlGenerator))
                         .toList();
 
         return response;

--- a/backend/src/main/java/com/heritage/platform/service/UserService.java
+++ b/backend/src/main/java/com/heritage/platform/service/UserService.java
@@ -208,15 +208,38 @@ public class UserService {
      */
     @Transactional(readOnly = true)
     public UserProfileResponse getUserProfile(UUID userId) {
+        return getUserProfile(userId, null);
+    }
+
+    /**
+     * Returns a user's public profile. Private fields are only included for
+     * the profile owner or administrators.
+     */
+    @Transactional(readOnly = true)
+    public UserProfileResponse getUserProfile(UUID userId, String requesterEmail) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new ResourceNotFoundException("User not found"));
 
-        List<Resource> publishedResources = resourceRepository.findByContributorId(userId)
-                .stream()
-                .filter(resource -> resource.getStatus() == ResourceStatus.APPROVED)
-                .peek(resourceService::initializeLazyAssociations)
-                .toList();
+        User requester = requesterEmail == null
+                ? null
+                : userRepository.findByEmail(requesterEmail).orElse(null);
 
-        return UserProfileResponse.fromEntity(user, publishedResources);
+        boolean includePrivateProfileFields = requester != null
+                && (requester.getId().equals(userId) || requester.getRole() == UserRole.ADMINISTRATOR);
+
+        List<Resource> publishedResources = user.isProfilePublic() || includePrivateProfileFields
+                ? resourceRepository.findByContributorId(userId)
+                        .stream()
+                        .filter(resource -> resource.getStatus() == ResourceStatus.APPROVED)
+                        .peek(resourceService::initializeLazyAssociations)
+                        .toList()
+                : List.of();
+
+        return UserProfileResponse.fromEntity(
+                user,
+                publishedResources,
+                fileService::generateDownloadUrl,
+                includePrivateProfileFields
+        );
     }
 }

--- a/backend/src/test/java/com/heritage/platform/service/UserServiceTest.java
+++ b/backend/src/test/java/com/heritage/platform/service/UserServiceTest.java
@@ -4,6 +4,7 @@ import com.heritage.platform.dto.UpdateProfileRequest;
 import com.heritage.platform.dto.UserProfileResponse;
 import com.heritage.platform.exception.ResourceNotFoundException;
 import com.heritage.platform.model.Category;
+import com.heritage.platform.model.FileReference;
 import com.heritage.platform.model.Resource;
 import com.heritage.platform.model.ResourceStatus;
 import com.heritage.platform.model.User;
@@ -283,6 +284,15 @@ class UserServiceTest {
                 ResourceStatus.APPROVED,
                 user
         );
+        approved.setThumbnailS3Key(approved.getId() + "/cover.jpg");
+        FileReference fileReference = new FileReference();
+        fileReference.setId(UUID.randomUUID());
+        fileReference.setResource(approved);
+        fileReference.setS3Key(approved.getId() + "/image.jpg");
+        fileReference.setOriginalFileName("image.jpg");
+        fileReference.setContentType("image/jpeg");
+        fileReference.setFileSize(123L);
+        approved.getFileReferences().add(fileReference);
         Resource draft = createTestResource(
                 UUID.randomUUID(),
                 "Draft Resource",
@@ -292,6 +302,10 @@ class UserServiceTest {
 
         when(userRepository.findById(userId)).thenReturn(Optional.of(user));
         when(resourceRepository.findByContributorId(userId)).thenReturn(List.of(approved, draft));
+        when(fileService.generateDownloadUrl(approved.getThumbnailS3Key()))
+                .thenReturn("/files/uploads/" + approved.getThumbnailS3Key());
+        when(fileService.generateDownloadUrl(fileReference.getS3Key()))
+                .thenReturn("/files/uploads/" + fileReference.getS3Key());
 
         UserProfileResponse result = userService.getUserProfile(userId);
 
@@ -299,6 +313,63 @@ class UserServiceTest {
         assertEquals("Test User", result.getDisplayName());
         assertEquals(1, result.getPublishedResources().size());
         assertEquals("Approved Resource", result.getPublishedResources().get(0).getTitle());
+        assertEquals(
+                "/files/uploads/" + approved.getThumbnailS3Key(),
+                result.getPublishedResources().get(0).getThumbnailUrl()
+        );
+        assertEquals(
+                "/files/uploads/" + fileReference.getS3Key(),
+                result.getPublishedResources().get(0).getFileReferences().get(0).getDownloadUrl()
+        );
+    }
+
+    @Test
+    void getUserProfile_privateProfile_hidesPrivateFieldsForPublicViewer() {
+        UUID userId = UUID.randomUUID();
+        User user = createTestUser(userId, "private@example.com", UserRole.CONTRIBUTOR);
+        user.setProfilePublic(false);
+        user.setShowEmail(true);
+        user.setContributorRequested(true);
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+
+        UserProfileResponse result = userService.getUserProfile(userId);
+
+        assertEquals(userId, result.getId());
+        assertEquals("Test User", result.getDisplayName());
+        assertFalse(result.isProfilePublic());
+        assertFalse(result.isShowEmail());
+        assertFalse(result.isContributorRequested());
+        assertNull(result.getEmail());
+        assertNull(result.getBio());
+        assertTrue(result.getPublishedResources().isEmpty());
+    }
+
+    @Test
+    void getUserProfile_privateProfile_includesPrivateFieldsForOwner() {
+        UUID userId = UUID.randomUUID();
+        User user = createTestUser(userId, "owner@example.com", UserRole.CONTRIBUTOR);
+        user.setProfilePublic(false);
+        user.setShowEmail(false);
+
+        Resource approved = createTestResource(
+                UUID.randomUUID(),
+                "Owner Resource",
+                ResourceStatus.APPROVED,
+                user
+        );
+
+        when(userRepository.findById(userId)).thenReturn(Optional.of(user));
+        when(userRepository.findByEmail("owner@example.com")).thenReturn(Optional.of(user));
+        when(resourceRepository.findByContributorId(userId)).thenReturn(List.of(approved));
+
+        UserProfileResponse result = userService.getUserProfile(userId, "owner@example.com");
+
+        assertEquals("owner@example.com", result.getEmail());
+        assertEquals("Test bio", result.getBio());
+        assertTrue(result.isShowEmail());
+        assertEquals(1, result.getPublishedResources().size());
+        assertEquals("Owner Resource", result.getPublishedResources().get(0).getTitle());
     }
 
     @Test

--- a/frontend/src/app/profile/page.tsx
+++ b/frontend/src/app/profile/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "@/lib/auth-context";
 import { apiClient, ApiError } from "@/lib/api-client";
 import { ProtectedRoute } from "@/components/protected-route";
@@ -10,7 +11,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Textarea } from "@/components/ui/textarea";
-import type { User } from "@/types";
+import type { User, UserProfileResponse } from "@/types";
 
 const ROLE_LABELS: Record<string, string> = {
   REGISTERED_VIEWER: "Registered Viewer",
@@ -66,6 +67,13 @@ function ProfileAvatarPreview({
 function ProfileContent() {
   const { user, refreshUser } = useAuth();
 
+  const publicProfileQuery = useQuery({
+    queryKey: ["user-profile", user?.id],
+    queryFn: () =>
+      apiClient.get<UserProfileResponse>(`/api/users/${user!.id}/profile`),
+    enabled: Boolean(user?.id),
+  });
+
   const [displayName, setDisplayName] = useState("");
   const [avatarUrl, setAvatarUrl] = useState("");
   const [bio, setBio] = useState("");
@@ -113,6 +121,7 @@ function ProfileContent() {
 
   const previewName = displayName.trim() || user.displayName || "User";
   const roleLabel = ROLE_LABELS[user.role] ?? user.role;
+  const publishedResources = publicProfileQuery.data?.publishedResources ?? [];
 
   const avatarPreviewToShow =
     selectedAvatarPreviewUrl || avatarUrl || user.avatarUrl || null;
@@ -493,13 +502,24 @@ function ProfileContent() {
             </div>
           </section>
 
-          {profilePublic && user.publishedResources && user.publishedResources.length > 0 && (
+          {profilePublic && publicProfileQuery.isLoading && (
+            <section>
+              <h2 className="font-serif text-[1.6rem] font-medium">
+                Published Resources
+              </h2>
+              <p className="mt-3 text-sm text-muted-foreground">
+                Loading published resources...
+              </p>
+            </section>
+          )}
+
+          {profilePublic && publishedResources.length > 0 && (
             <section>
               <h2 className="font-serif text-[1.6rem] font-medium">
                 Published Resources
               </h2>
               <div className="mt-5 grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3">
-                {user.publishedResources.map((resource) => (
+                {publishedResources.map((resource) => (
                   <ResourceCard key={resource.id} resource={resource} />
                 ))}
               </div>

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -22,7 +22,7 @@ export interface User {
 
 export interface UserProfileResponse {
   id: string;
-  email: string;
+  email: string | null;
   displayName: string;
   role: UserRole;
   contributorRequested: boolean;


### PR DESCRIPTION
## Summary

- Fix public contributor profile resource cards not rendering images by returning `thumbnailUrl` / file `downloadUrl` for published resources.
- Add backend-side privacy filtering for public profiles so private profile data is not exposed through the API.
- Update the current user profile page to load published resources from the public profile endpoint instead of relying on a missing `user.publishedResources` field.
- Add service tests for published resource image URLs and private profile visibility behavior.

## Verification

- `mvn compile` ✅
- `npx tsc --noEmit` ✅
- `npm run build` ✅
- `npm run lint` ✅ 0 errors, existing warnings remain
- `mvn -DskipTests test-compile` ❌ fails in the existing backend test compile setup with broad missing-symbol errors for main classes such as `User`, `UserRole`, `ResourceStatus`, repositories, and services. Main backend compilation succeeds, so this appears separate from the profile fix.

## Notes

This PR fixes the comment-user-profile navigation symptom: resources on `/users/:id` now receive usable image URLs and should render their card images correctly.